### PR TITLE
Change more default settings 

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -130,10 +130,10 @@ struct islope_t
 //
 //=============================================================================
 
-CVAR(Bool, am_textured, false, CVAR_ARCHIVE)
+CVAR(Bool, am_textured, true, CVAR_ARCHIVE)
 CVAR(Float, am_linealpha, 1.0f, CVAR_ARCHIVE)
-CVAR(Int, am_linethickness, 1, CVAR_ARCHIVE)
-CVAR(Int, am_lineantialiasing, 0, CVAR_ARCHIVE)
+CVAR(Int, am_linethickness, 2, CVAR_ARCHIVE)
+CVAR(Int, am_lineantialiasing, 1, CVAR_ARCHIVE)
 CVAR(Bool, am_thingrenderstyles, true, CVAR_ARCHIVE)
 CVAR(Int, am_showsubsector, -1, 0);
 
@@ -159,7 +159,7 @@ CVAR(Int, am_rotate, 0, CVAR_ARCHIVE);
 CVAR(Int, am_overlay, 0, CVAR_ARCHIVE);
 CVAR(Bool, am_showsecrets, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showmonsters, true, CVAR_ARCHIVE);
-CVAR(Bool, am_showitems, false, CVAR_ARCHIVE);
+CVAR(Bool, am_showitems, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showtime, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showtotaltime, false, CVAR_ARCHIVE);
 CVAR(Int, am_colorset, 0, CVAR_ARCHIVE);

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -47,7 +47,7 @@ static F2DDrawer drawer = F2DDrawer();
 F2DDrawer* twod = &drawer;
 
 EXTERN_CVAR(Float, transsouls)
-CVAR(Float, classic_scaling_factor, 1.0, CVAR_ARCHIVE)
+CVAR(Float, classic_scaling_factor, 2.0, CVAR_ARCHIVE)
 CVAR(Float, classic_scaling_pixelaspect, 1.2f, CVAR_ARCHIVE)
 
 IMPLEMENT_CLASS(FCanvas, false, false)

--- a/src/common/cutscenes/screenjob.cpp
+++ b/src/common/cutscenes/screenjob.cpp
@@ -52,7 +52,7 @@
 #include "m_argv.h"
 #include "i_interface.h"
 
-CVAR(Bool, inter_subtitles, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
+CVAR(Bool, inter_subtitles, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 
 CutsceneState cutscene;
 static int ticks;

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -64,7 +64,7 @@ CVAR (Int, m_showinputgrid, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, m_blockcontrollers, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 CVAR (Float, snd_menuvolume, 0.6f, CVAR_ARCHIVE)
-CVAR(Int, m_use_mouse, 2, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR(Int, m_use_mouse, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Int, m_show_backbutton, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Bool, m_cleanscale, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 // Option Search

--- a/src/common/rendering/hwrenderer/data/hw_cvars.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.cpp
@@ -56,7 +56,7 @@ CUSTOM_CVAR(Int, gl_fogmode, 2, CVAR_ARCHIVE | CVAR_NOINITCALL)
 CVAR(Bool, gl_portals, true, 0)
 CVAR(Bool,gl_mirrors,true,0)	// This is for debugging only!
 CVAR(Bool,gl_mirror_envmap, true, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-CVAR(Bool, gl_seamless, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR(Bool, gl_seamless, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 CUSTOM_CVAR(Int, r_mirror_recursions,4,CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
 {

--- a/src/common/startscreen/endoom.cpp
+++ b/src/common/startscreen/endoom.cpp
@@ -67,7 +67,7 @@
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
-CUSTOM_CVAR(Int, showendoom, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CUSTOM_CVAR(Int, showendoom, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
 	if (self < 0) self = 0;
 	else if (self > 2) self=2;

--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -59,8 +59,8 @@ IMPLEMENT_CLASS(DHUDFont, false, false);
 
 CVAR(Color, crosshaircolor, 0xff0000, CVAR_ARCHIVE);
 CVAR(Int, crosshairhealth, 2, CVAR_ARCHIVE);
-CVARD(Float, crosshairscale, 0.5, CVAR_ARCHIVE, "changes the size of the crosshair");
-CVAR(Bool, crosshairgrow, false, CVAR_ARCHIVE);
+CVARD(Float, crosshairscale, 0.2f, CVAR_ARCHIVE, "changes the size of the crosshair");
+CVAR(Bool, crosshairgrow, true, CVAR_ARCHIVE);
 
 CUSTOM_CVARD(Float, hud_scalefactor, 1.f, CVAR_ARCHIVE, "changes the hud scale")
 {

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -54,7 +54,7 @@
 
 static FRandom pr_pickteam ("PickRandomTeam");
 
-CVAR (Float,	autoaim,				35.f,		CVAR_USERINFO | CVAR_ARCHIVE);
+CVAR (Float,	autoaim,				0.f,		CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (String,	name,					"Player",	CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Color,	color,					0x40cf00,	CVAR_USERINFO | CVAR_ARCHIVE);
 CVAR (Int,		colorset,				0,			CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/g_cvars.cpp
+++ b/src/g_cvars.cpp
@@ -122,10 +122,10 @@ CUSTOM_CVAR (Int, cl_maxdecals, 1024, CVAR_ARCHIVE|CVAR_NOINITCALL)
 
 // [BC] Allow the maximum number of particles to be specified by a cvar (so people
 // with lots of nice hardware can have lots of particles!).
-CUSTOM_CVAR(Int, r_maxparticles, 4000, CVAR_ARCHIVE | CVAR_NOINITCALL)
+CUSTOM_CVAR(Int, r_maxparticles, 10000, CVAR_ARCHIVE | CVAR_NOINITCALL)
 {
 	if (self == 0)
-		self = 4000;
+		self = 10000;
 	else if (self > 65535)
 		self = 65535;
 	else if (self < 100)

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -131,7 +131,7 @@ EXTERN_CVAR (Float, con_midtime);
 //
 //==========================================================================
 
-CUSTOM_CVAR (Int, displaynametags, 0, CVAR_ARCHIVE)
+CUSTOM_CVAR (Int, displaynametags, 3, CVAR_ARCHIVE)
 {
 	if (self < 0 || self > 3)
 	{
@@ -201,7 +201,7 @@ int				lookspeed[2] = {450, 512};
 
 #define SLOWTURNTICS	6 
 
-CVAR (Bool,		cl_run,			false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always run?
+CVAR (Bool,		cl_run,			true,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always run?
 CVAR (Bool,		invertmouse,	false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Invert mouse look down/up?
 CVAR (Bool,		invertmousex,	false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Invert mouse look left/right?
 CVAR (Bool,		freelook,		true,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always mlook?
@@ -2179,7 +2179,7 @@ CCMD(opensaves)
 CVAR (Int, autosavenum, 0, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 static int nextautosave = -1;
 CVAR (Int, disableautosave, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-CVAR (Bool, saveloadconfirmation, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // [mxd]
+CVAR (Bool, saveloadconfirmation, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // [mxd]
 CUSTOM_CVAR (Int, autosavecount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
 	if (self < 0)
@@ -2187,7 +2187,7 @@ CUSTOM_CVAR (Int, autosavecount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 }
 CVAR (Int, quicksavenum, -1, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 static int lastquicksave = -1;
-CVAR (Bool, quicksaverotation, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR (Bool, quicksaverotation, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CUSTOM_CVAR (Int, quicksaverotationcount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
 	if (self < 1)

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -122,7 +122,7 @@ EXTERN_CVAR(Float, hud_scalefactor)
 EXTERN_CVAR(Bool, hud_aspectscale)
 
 CVAR (Bool, crosshairon, true, CVAR_ARCHIVE);
-CVAR (Int, crosshair, 0, CVAR_ARCHIVE)
+CVAR (Int, crosshair, 1, CVAR_ARCHIVE)
 CVAR (Bool, crosshairforce, false, CVAR_ARCHIVE)
 CUSTOM_CVAR(Int, am_showmaplabel, 2, CVAR_ARCHIVE)
 {

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -152,7 +152,7 @@ CUSTOM_CVAR (Float, sv_gravity, 800.f, CVAR_SERVERINFO|CVAR_NOSAVE|CVAR_NOINITCA
 }
 
 CVAR (Bool, cl_missiledecals, true, CVAR_ARCHIVE)
-CVAR (Bool, addrocketexplosion, false, CVAR_ARCHIVE)
+CVAR (Bool, addrocketexplosion, true, CVAR_ARCHIVE)
 CVAR (Int, cl_pufftype, 0, CVAR_ARCHIVE);
 CVAR (Int, cl_bloodtype, 0, CVAR_ARCHIVE);
 

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -35,7 +35,7 @@
 static float distfogtable[2][256];	// light to fog conversion table for black fog
 
 CVAR(Int, gl_weaponlight, 8, CVAR_ARCHIVE);
-CVAR(Bool, gl_enhanced_nightvision, true, CVAR_ARCHIVE|CVAR_NOINITCALL)
+CVAR(Bool, gl_enhanced_nightvision, false, CVAR_ARCHIVE|CVAR_NOINITCALL)
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -78,10 +78,10 @@ EXTERN_CVAR(Float, r_actorspriteshadowfadeheight)
 
 CVAR(Bool, gl_usecolorblending, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_sprite_blend, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
-CVAR(Int, gl_spriteclip, 1, CVAR_ARCHIVE)
+CVAR(Int, gl_spriteclip, 2, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipthreshold, 10.0, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipfactor, 1.8f, CVAR_ARCHIVE)
-CVAR(Int, gl_particles_style, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
+CVAR(Int, gl_particles_style, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
 CVAR(Int, gl_billboard_mode, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_billboard_faces_camera, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_billboard_particles, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -952,7 +952,7 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_ROCKETTRAILS",			"cl_rockettrails", "RocketTrailTypes"
 	Option "$DSPLYMNU_BLOODTYPE",				"cl_bloodtype", "BloodTypes"
 	Option "$DSPLYMNU_PUFFTYPE",				"cl_pufftype", "PuffTypes"
-	Slider "$DSPLYMNU_MAXPARTICLES",			"r_maxparticles", 100, 10000, 100, 0
+	Slider "$DSPLYMNU_MAXPARTICLES",			"r_maxparticles", 100, 65535, 100, 0
 	Slider "$DSPLYMNU_MAXDECALS",				"cl_maxdecals", 0, 10000, 100, 0
 	Option "$DSPLYMNU_PLAYERSPRITES",			"r_drawplayersprites", "OnOff"
 	Option "$DSPLYMNU_DEATHCAM",				"r_deathcamera", "OnOff"


### PR DESCRIPTION
- Show item counter on automap
- Enable thicker automap lines and anti-aliased lines for better visibility with high res displays
- Enable textured automap
- HUD border scaling factor to better match default status bar scaling
- Enable subtitles
- Set render quality to "quality" to fix level mesh seams (gl_seamless)
- Enable mouse in menus by default (instead of touchscreen-like)
- Don't show ENDDOOM when quitting the app
- Enable the first crosshair, and set its scale slightly smaller
- Grow crosshair when picking up items
- Set autoaim slider to 0
- Show nametags when switching items and weapons
- Always run enabled
- Disable save/load confirmation dialog
- Enable quicksave rotation
- Enable additively-translucent Doom rocket explosion
- Increase default particles to 10k, and increase the slider to 65k (engine limit)
- Disable night vision effect
- Set sprite clipping to "Always" as this looks better than having sprites sink into the geometry
- Set particle style to round as it matches the pixelated aesthetics better