### PR TITLE
Add MAPINFO NoAutoSaveOnEnter

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1509,6 +1509,12 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	DoDeferedScripts ();	// [RH] Do script actions that were triggered on another map.
 	
 
+	// [Nash] allow modder control of autosaving
+	if (flags9 & LEVEL9_NOAUTOSAVEONENTER)
+	{
+		autosave = false;
+	}
+
 	// [RH] Always save the game when entering a new 
 	if (autosave && !savegamerestore && disableautosave < 1)
 	{

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1796,6 +1796,7 @@ MapFlagHandlers[] =
 	{ "forceworldpanning",				MITYPE_SETFLAG3,	LEVEL3_FORCEWORLDPANNING, 0 },
 	{ "nousersave",						MITYPE_SETFLAG9,	LEVEL9_NOUSERSAVE, 0 },
 	{ "noautomap",						MITYPE_SETFLAG9,	LEVEL9_NOAUTOMAP, 0 },
+	{ "noautosaveonenter",				MITYPE_SETFLAG9,	LEVEL9_NOAUTOSAVEONENTER, 0 },
 	{ "propermonsterfallingdamage",		MITYPE_SETFLAG3,	LEVEL3_PROPERMONSTERFALLINGDAMAGE, 0 },
 	{ "disableshadowmap",				MITYPE_SETFLAG3,	LEVEL3_NOSHADOWMAP, 0 },
 	{ "enableshadowmap",				MITYPE_CLRFLAG3,	LEVEL3_NOSHADOWMAP, 0 },

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -275,6 +275,7 @@ enum ELevelFlags : unsigned int
 	// Deliberately skip ahead...
 	LEVEL9_NOUSERSAVE			= 0x00000001,
 	LEVEL9_NOAUTOMAP			= 0x00000002,
+	LEVEL9_NOAUTOSAVEONENTER	= 0x00000004,	// don't make an autosave when entering a map
 };
 
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1382,6 +1382,7 @@ enum ELevelFlags
 
 	LEVEL9_NOUSERSAVE			= 0x00000001,
 	LEVEL9_NOAUTOMAP			= 0x00000002,
+    LEVEL9_NOAUTOSAVEONENTER	= 0x00000004,	// don't make an autosave when entering a map
 };
 
 // [RH] Compatibility flags.


### PR DESCRIPTION
This fully disables autosaves when a map is just entered (ignoring the user's autosave preference).

There are some legitimate use cases where a modder might want to set a map up to not autosave upon entry. Perhaps said map was intended to be some intermediary non-gameplay map.

Example file specifically disables autosave-upon-entry for Doom 2 MAP02: [NoAutosaveOnEnter.zip](https://github.com/dpjudas/VkDoom/files/12061774/NoAutosaveOnEnter.zip)
