### PR TITLE
Add CHANGELEVEL_NOAUTOSAVE flag to ChangeLevel to allow…

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1425,6 +1425,10 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 	{
 		flags2 |= LEVEL2_PRERAISEWEAPON;
 	}
+	if (changeflags & CHANGELEVEL_NOAUTOSAVE)
+	{
+		flags9 |= LEVEL9_NOAUTOSAVEONENTER;
+	}
 
 	maptime = 0;
 

--- a/src/g_level.h
+++ b/src/g_level.h
@@ -27,6 +27,7 @@ enum
 	CHANGELEVEL_NOINTERMISSION = 16,
 	CHANGELEVEL_RESETHEALTH = 32,
 	CHANGELEVEL_PRERAISEWEAPON = 64,
+	CHANGELEVEL_NOAUTOSAVE = 128,
 };
 
 void G_DoLoadLevel (const FString &MapName, int position, bool autosave, bool newGame);

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1263,6 +1263,7 @@ enum EChangeLevelFlags
 	CHANGELEVEL_NOINTERMISSION = 16,
 	CHANGELEVEL_RESETHEALTH = 32,
 	CHANGELEVEL_PRERAISEWEAPON = 64,
+	CHANGELEVEL_NOAUTOSAVE = 128,
 };
 
 enum ELevelFlags
@@ -1382,7 +1383,7 @@ enum ELevelFlags
 
 	LEVEL9_NOUSERSAVE			= 0x00000001,
 	LEVEL9_NOAUTOMAP			= 0x00000002,
-    LEVEL9_NOAUTOSAVEONENTER	= 0x00000004,	// don't make an autosave when entering a map
+	LEVEL9_NOAUTOSAVEONENTER	= 0x00000004,	// don't make an autosave when entering a map
 };
 
 // [RH] Compatibility flags.


### PR DESCRIPTION
scripted level-switching to bypass autosaving

Example file - pressing Jump calls a ChangeLevel command in ZScript that would, under normal circumstances, create an autosave; but with this mod, it now does not.

[ChangeLevelNoAutosave.zip](https://github.com/dpjudas/VkDoom/files/12062266/ChangeLevelNoAutosave.zip)
