### PR TITLE
Fix bugs and copy lightmapper output to the atlas

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_levelmesh.h
+++ b/src/common/rendering/hwrenderer/data/hw_levelmesh.h
@@ -106,6 +106,11 @@ struct Surface
 
 	// Output lightmap for the surface
 	std::vector<FVector3> texPixels;
+
+	// Lightmapper has a lot of additional padding around the borders
+	int lightmapperAtlasPage = -1;
+	int lightmapperAtlasX = -1;
+	int lightmapperAtlasY = -1;
 };
 
 
@@ -222,29 +227,6 @@ public:
 	{
 		FVector3 end = start + direction * std::max(maxDist - 10.0f, 0.0f);
 		return !TriangleMeshShape::find_any_hit(Collision.get(), start, end);
-	}
-
-	inline void FinishSurface(int lightmapTextureWidth, int lightmapTextureHeight, RectPacker& packer, Surface& surface)
-	{
-		int sampleWidth = surface.texWidth;
-		int sampleHeight = surface.texHeight;
-
-		auto result = packer.insert(sampleWidth, sampleHeight);
-		int x = result.pos.x, y = result.pos.y;
-		surface.atlasPageIndex = (int)result.pageIndex;
-
-		// calculate final texture coordinates
-		for (unsigned i = 0; i < surface.uvs.Size(); i++)
-		{
-			auto& u = surface.uvs[i].X;
-			auto& v = surface.uvs[i].Y;
-			u = (u + x) / (float)lightmapTextureWidth;
-			v = (v + y) / (float)lightmapTextureHeight;
-		}
-
-		surface.atlasX = x;
-		surface.atlasY = y;
-
 	}
 };
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -49,6 +49,11 @@ void VkLightmap::Raytrace(hwrenderer::LevelMesh* level)
 	}
 
 	FinishCommands();
+
+	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
+	{
+		DownloadAtlasImage(pageIndex);
+	}
 }
 
 void VkLightmap::BeginCommands()
@@ -96,13 +101,13 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex)
 	for (unsigned int i = 0; i < mesh->Surfaces.Size(); i++)
 	{
 		hwrenderer::Surface* targetSurface = &mesh->Surfaces[i];
-		if (targetSurface->atlasPageIndex != pageIndex)
+		if (targetSurface->lightmapperAtlasPage != pageIndex)
 			continue;
 
 		VkViewport viewport = {};
 		viewport.maxDepth = 1;
-		viewport.x = (float)targetSurface->atlasX - 1;
-		viewport.y = (float)targetSurface->atlasY - 1;
+		viewport.x = (float)targetSurface->lightmapperAtlasX - 1;
+		viewport.y = (float)targetSurface->lightmapperAtlasY - 1;
 		viewport.width = (float)(targetSurface->texWidth + 2);
 		viewport.height = (float)(targetSurface->texHeight + 2);
 		cmdbuffer->setViewport(0, 1, &viewport);
@@ -199,9 +204,9 @@ void VkLightmap::CreateAtlasImages()
 		hwrenderer::Surface* surface = &mesh->Surfaces[i];
 
 		auto result = packer.insert(surface->texWidth + 2, surface->texHeight + 2);
-		surface->atlasX = result.pos.x + 1;
-		surface->atlasY = result.pos.y + 1;
-		surface->atlasPageIndex = (int)result.pageIndex;
+		surface->lightmapperAtlasX = result.pos.x + 1;
+		surface->lightmapperAtlasY = result.pos.y + 1;
+		surface->lightmapperAtlasPage = (int)result.pageIndex;
 	}
 
 	for (size_t pageIndex = 0; pageIndex < packer.getNumPages(); pageIndex++)
@@ -306,18 +311,18 @@ void VkLightmap::DownloadAtlasImage(size_t pageIndex)
 	for (unsigned int i = 0; i < mesh->Surfaces.Size(); i++)
 	{
 		hwrenderer::Surface* surface = &mesh->Surfaces[i];
-		if (surface->atlasPageIndex != pageIndex)
+		if (surface->lightmapperAtlasPage != pageIndex)
 			continue;
 
-		int atlasX = surface->atlasX;
-		int atlasY = surface->atlasY;
+		int lightmapperAtlasX = surface->lightmapperAtlasX;
+		int lightmapperAtlasY = surface->lightmapperAtlasY;
 		int sampleWidth = surface->texWidth;
 		int sampleHeight = surface->texHeight;
 
 		for (int y = 0; y < sampleHeight; y++)
 		{
 			FVector3* dest = &surface->texPixels[y * sampleWidth];
-			hvec4* src = &pixels[atlasX + (atlasY + y) * atlasImageSize];
+			hvec4* src = &pixels[lightmapperAtlasX + (lightmapperAtlasY + y) * atlasImageSize];
 			for (int x = 0; x < sampleWidth; x++)
 			{
 				dest[x] = src[x].xyz();

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -551,21 +551,13 @@ void VulkanRenderDevice::SetLevelMesh(hwrenderer::LevelMesh* mesh)
 		Printf("Copying data.\n");
 
 		// TODO refactor
-
 		auto clamp = [](float a, float min, float max) -> float { return a < min ? min : a > max ? max : a; };
-
-		// BUG: This is a destructive action as it reorders the surfaces array that is indexed by MeshSurfaces
-		std::sort(mesh->Surfaces.begin(), mesh->Surfaces.end(), [](const hwrenderer::Surface& a, const hwrenderer::Surface& b) { return a.texHeight != b.texHeight ? a.texHeight > b.texHeight : a.texWidth > b.texWidth; });
-
-		RectPacker packer(mesh->LMTextureSize, mesh->LMTextureSize, RectPacker::Spacing(0));
 
 		TArray<uint16_t> LMTextureData;
 		LMTextureData.Resize(mesh->LMTextureSize * mesh->LMTextureSize * mesh->LMTextureCount * 3);
 
 		for (auto& surface : mesh->Surfaces)
 		{
-			mesh->FinishSurface(mesh->LMTextureSize, mesh->LMTextureSize, packer, surface);
-
 			uint16_t* currentTexture = LMTextureData.Data() + (mesh->LMTextureSize * mesh->LMTextureSize * 3) * surface.atlasPageIndex;
 
 			FVector3* colorSamples = surface.texPixels.data();

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -567,7 +567,7 @@ void VulkanRenderDevice::SetLevelMesh(hwrenderer::LevelMesh* mesh)
 				for (int j = 0; j < surface.texWidth; j++)
 				{
 					// get texture offset
-					int offs = ((surface.texWidth * (i + surface.atlasY)) + surface.atlasX) * 3;
+					int offs = ((mesh->LMTextureSize * (i + surface.atlasY)) + surface.atlasX) * 3;
 
 					// convert RGB to bytes
 					currentTexture[offs + j * 3 + 0] = floatToHalf(clamp(colorSamples[i * surface.texWidth + j].X, 0.0f, 65000.0f));

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -622,62 +622,36 @@ void DoomLevelMesh::SetupLightmapUvs()
 		sortedSurfaces.push_back(&surface);
 	}
 
-#if 0
-	for (const auto& surface : Surfaces)
+	// VkLightmapper old ZDRay properties
+	for (auto& surface : Surfaces)
 	{
-		hwrenderer::Surface hwSurface;
+		for (int i = 0; i < surface.numVerts; ++i)
+		{
+			surface.verts.Push(MeshVertices[surface.startVertIndex + i]);
+		}
 
 		for (int i = 0; i < surface.numVerts; ++i)
 		{
-			hwSurface->verts.Push(MeshVertices[surface.startVertIndex + i]);
+			surface.uvs.Push(LightmapUvs[surface.startUvIndex + i]);
 		}
 
-		for (int i = 0; i < surface.numVerts; ++i)
-		{
-			hwSurface->uvs.Push(LightmapUvs[surface.startUvIndex + i]);
-		}
-
-		hwSurface->boundsMax = surface.bounds.max;
-		hwSurface->boundsMin = surface.bounds.min;
-
-		hwSurface->projLocalToU = surface.projLocalToU;
-		hwSurface->projLocalToV = surface.projLocalToV;
-		hwSurface->smoothingGroupIndex = 0;
-		hwSurface->texHeight = surface.texHeight;
-		hwSurface->texWidth = surface.texWidth;
-
-		hwSurface->translateWorldToLocal = surface.translateWorldToLocal;
-		hwSurface->type = hwrenderer::SurfaceType(surface.type);
-
-		hwSurface->texPixels.resize(surface.texWidth * surface.texHeight);
-
-		for (auto& pixel : hwSurface->texPixels)
-		{
-			pixel.X = 0.0;
-			pixel.Y = 1.0;
-			pixel.Z = 0.0;
-		}
-
-		// TODO push
-		Surfaces.push_back(hwSurface);
+		surface.texPixels.resize(surface.texWidth * surface.texHeight);
 
 		SurfaceInfo info;
 		info.Normal = surface.plane.XYZ();
 		info.PortalIndex = 0;
 		info.SamplingDistance = (float)surface.sampleDimension;
 		info.Sky = surface.bSky;
-
 		surfaceInfo.Push(info);
-
-
 	}
-#endif
 
 	{
 		hwrenderer::SmoothingGroup smoothing;
 
 		for (auto& surface : Surfaces)
 		{
+			surface.smoothingGroupIndex = 0;
+
 			smoothing.surfaces.push_back(&surface);
 		}
 		smoothingGroups.Push(std::move(smoothing));
@@ -912,7 +886,6 @@ void DoomLevelMesh::BuildSurfaceParams(int lightMapTextureWidth, int lightMapTex
 
 	surface.texWidth = width;
 	surface.texHeight = height;
-	//surface->texPixels.resize(width * height);
 	surface.worldOrigin = tOrigin;
 	surface.worldStepX = tCoords[0] * (float)surface.sampleDimension;
 	surface.worldStepY = tCoords[1] * (float)surface.sampleDimension;

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -77,7 +77,7 @@ private:
 	static PlaneAxis BestAxis(const FVector4& p);
 	BBox GetBoundsFromSurface(const hwrenderer::Surface& surface) const;
 
-	inline int AllocUvs(int amount) { return LightmapUvs.Reserve(amount * 2); }
+	inline int AllocUvs(int amount) { return LightmapUvs.Reserve(amount); }
 
 	void BuildSurfaceParams(int lightMapTextureWidth, int lightMapTextureHeight, hwrenderer::Surface& surface);
 	void FinishSurface(int lightmapTextureWidth, int lightmapTextureHeight, RectPacker& packer, hwrenderer::Surface& surface);


### PR DESCRIPTION
Now it runs the lightmapper, downloads the output and copies it onto the texture atlas.

The issues are:
1. the buffers the lightmapper shader uses aren't filled... (Maybe?)
2. the lightmapper runs every frame.