### PR TITLE
Partial Lightmapper

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_levelmesh.h
+++ b/src/common/rendering/hwrenderer/data/hw_levelmesh.h
@@ -52,6 +52,8 @@ struct LevelMeshSurface
 	int texWidth = 0;
 	int texHeight = 0;
 
+	bool needsUpdate = true;
+
 	//
 	// Required for internal lightmapper:
 	//

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -263,7 +263,7 @@ protected:
 	EPassType mPassType = NORMAL_PASS;
 
 	std::atomic<unsigned> mActiveLightmapSurfaceBufferIndex;
-	TArray<int> mActiveLightmapSurfacesBuffer;
+	TArray<LevelMeshSurface*> mActiveLightmapSurfacesBuffer;
 public:
 
 	uint64_t firstFrame = 0;
@@ -746,7 +746,7 @@ public:
 			int index = mActiveLightmapSurfaceBufferIndex.fetch_add(1);
 			if (index < mActiveLightmapSurfacesBuffer.Size())
 			{
-				mActiveLightmapSurfacesBuffer[index] = surfaceIndex;
+				mActiveLightmapSurfacesBuffer[index] = surface;
 				surface->needsUpdate = false;
 			}
 		}

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -735,7 +735,7 @@ public:
 
 	inline void PushVisibleSurface(int surfaceIndex, LevelMeshSurface* surface)
 	{
-		if(surface->needsUpdate && mActiveLightmapSurfaces.Size() < lm_max_updates && mActiveLightmapSurfaces.Find(surfaceIndex) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
+		if(surface->needsUpdate && mActiveLightmapSurfaces.Size() < unsigned(lm_max_updates) && mActiveLightmapSurfaces.Find(surfaceIndex) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
 			mActiveLightmapSurfaces.Push(surfaceIndex);
 	}
 

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -258,7 +258,7 @@ protected:
 
 	EPassType mPassType = NORMAL_PASS;
 
-	TArray<LevelMeshSurface*> mActiveLightmapSurfaces;
+	TArray<int> mActiveLightmapSurfaces;
 public:
 
 	uint64_t firstFrame = 0;
@@ -731,10 +731,10 @@ public:
 		return SetViewpoint(matrices);
 	}
 
-	inline void PushVisibleSurface(LevelMeshSurface* surface)
+	inline void PushVisibleSurface(int surfaceIndex, LevelMeshSurface* surface)
 	{
-		if(surface && surface->needsUpdate && mActiveLightmapSurfaces.Find(surface) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
-			mActiveLightmapSurfaces.Push(surface);
+		if(surface->needsUpdate && mActiveLightmapSurfaces.Find(surfaceIndex) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
+			mActiveLightmapSurfaces.Push(surfaceIndex);
 	}
 
 	inline const auto& GetVisibleSurfaceList() const

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -10,6 +10,8 @@
 #include "hw_viewpointuniforms.h"
 #include "hw_cvars.h"
 
+EXTERN_CVAR(Int, lm_max_updates);
+
 struct FColormap;
 class IBuffer;
 struct HWViewpointUniforms;
@@ -733,11 +735,11 @@ public:
 
 	inline void PushVisibleSurface(int surfaceIndex, LevelMeshSurface* surface)
 	{
-		if(surface->needsUpdate && mActiveLightmapSurfaces.Find(surfaceIndex) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
+		if(surface->needsUpdate && mActiveLightmapSurfaces.Size() < lm_max_updates && mActiveLightmapSurfaces.Find(surfaceIndex) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
 			mActiveLightmapSurfaces.Push(surfaceIndex);
 	}
 
-	inline const auto& GetVisibleSurfaceList() const
+	inline auto& GetVisibleSurfaceList()
 	{
 		return mActiveLightmapSurfaces;
 	}

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -3,6 +3,7 @@
 #include "vectors.h"
 #include "matrix.h"
 #include "hw_material.h"
+#include "hw_levelmesh.h"
 #include "texmanip.h"
 #include "version.h"
 #include "i_interface.h"
@@ -257,6 +258,7 @@ protected:
 
 	EPassType mPassType = NORMAL_PASS;
 
+	TArray<LevelMeshSurface*> mActiveLightmapSurfaces;
 public:
 
 	uint64_t firstFrame = 0;
@@ -727,6 +729,22 @@ public:
 		matrices.mProjectionMatrix.ortho(0, (float)width, (float)height, 0, -1.0f, 1.0f);
 		matrices.CalcDependencies();
 		return SetViewpoint(matrices);
+	}
+
+	inline void PushVisibleSurface(LevelMeshSurface* surface)
+	{
+		if(surface && surface->needsUpdate && mActiveLightmapSurfaces.Find(surface) >= mActiveLightmapSurfaces.Size()) // yikes, how awful
+			mActiveLightmapSurfaces.Push(surface);
+	}
+
+	inline const auto& GetVisibleSurfaceList() const
+	{
+		return mActiveLightmapSurfaces;
+	}
+
+	inline void ClearVisibleSurfaceList()
+	{
+		mActiveLightmapSurfaces.Clear();
 	}
 
 	// API-dependent render interface

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -156,6 +156,7 @@ public:
 	virtual bool IsPoly() { return false; }
 	virtual bool CompileNextShader() { return true; }
 	virtual void SetLevelMesh(LevelMesh *mesh) { }
+	virtual void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) {}
 	bool allowSSBO() const
 	{
 #ifndef HW_BLOCK_SSBO

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -156,7 +156,7 @@ public:
 	virtual bool IsPoly() { return false; }
 	virtual bool CompileNextShader() { return true; }
 	virtual void SetLevelMesh(LevelMesh *mesh) { }
-	virtual void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) {}
+	virtual void UpdateLightmaps(const TArray<int>& surfaceIndices) {}
 	bool allowSSBO() const
 	{
 #ifndef HW_BLOCK_SSBO

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -156,7 +156,7 @@ public:
 	virtual bool IsPoly() { return false; }
 	virtual bool CompileNextShader() { return true; }
 	virtual void SetLevelMesh(LevelMesh *mesh) { }
-	virtual void UpdateLightmaps(const TArray<int>& surfaceIndices) {}
+	virtual void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) {}
 	bool allowSSBO() const
 	{
 #ifndef HW_BLOCK_SSBO

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -49,7 +49,7 @@ VkLightmap::~VkLightmap()
 #include <set>
 #endif
 
-void VkLightmap::Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices)
+void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces)
 {
 	bool newLevel = (mesh != level);
 	mesh = level;
@@ -68,9 +68,9 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices)
 	lightmapRaytrace.Clock();
 	lightmapRaytraceLast.ResetAndClock();
 
-	CreateAtlasImages(surfaceIndices);
+	CreateAtlasImages(surfaces);
 
-#if 0
+#if 0 // SmoothGroups
 	TArray<int> allSurfaces;
 
 	std::set<int> s;
@@ -91,12 +91,7 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices)
 		}
 	}
 #else
-	for (auto& surface : surfaceIndices)
-	{
-		mesh->GetSurface(surface)->needsUpdate = false;
-	}
-
-	const auto& allSurfaces = surfaceIndices;
+	const auto& allSurfaces = surfaces;
 #endif
 
 	UploadUniforms();
@@ -125,7 +120,7 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices)
 	lightmapRaytraceLast.Unclock();
 }
 
-void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIndices)
+void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
@@ -147,9 +142,9 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIn
 		cmdbuffer->bindDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, raytrace.pipelineLayout.get(), 1, raytrace.descriptorSet1.get());
 	}
 
-	for (int i = 0, count = surfaceIndices.Size(); i < count; i++)
+	for (int i = 0, count = surfaces.Size(); i < count; i++)
 	{
-		LevelMeshSurface* targetSurface = mesh->GetSurface(surfaceIndices[i]);
+		LevelMeshSurface* targetSurface = surfaces[i];
 		if (targetSurface->lightmapperAtlasPage != pageIndex)
 			continue;
 
@@ -258,7 +253,7 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIn
 	fb->GetCommands()->GetTransferCommands()->endRenderPass();
 }
 
-void VkLightmap::CreateAtlasImages(const TArray<int>& surfaceIndices)
+void VkLightmap::CreateAtlasImages(const TArray<LevelMeshSurface*>& surfaces)
 {
 	for (auto& page : atlasImages)
 	{
@@ -271,9 +266,9 @@ void VkLightmap::CreateAtlasImages(const TArray<int>& surfaceIndices)
 
 	size_t pageIndex = atlasImages.size();
 
-	for (int i = 0, count = surfaceIndices.Size(); i < count; i++)
+	for (int i = 0, count = surfaces.Size(); i < count; i++)
 	{
-		LevelMeshSurface* surface = mesh->GetSurface(surfaceIndices[i]);
+		LevelMeshSurface* surface = surfaces[i];
 	//for (int i = 0, count = mesh->GetSurfaceCount(); i < count; i++)
 	//{
 		//LevelMeshSurface* surface = mesh->GetSurface(i);
@@ -458,14 +453,14 @@ void VkLightmap::BlurAtlasImage(size_t pageIndex)
 	}
 }
 
-void VkLightmap::CopyAtlasImageResult(size_t pageIndex, const TArray<int>& surfaceIndices)
+void VkLightmap::CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
 	std::vector<VkImageCopy> regions;
-	for (int i = 0, count = surfaceIndices.Size(); i < count; i++)
+	for (int i = 0, count = surfaces.Size(); i < count; i++)
 	{
-		LevelMeshSurface* surface = mesh->GetSurface(surfaceIndices[i]);
+		LevelMeshSurface* surface = surfaces[i];
 		if (surface->lightmapperAtlasPage != pageIndex)
 			continue;
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -41,10 +41,21 @@ ADD_STAT(lightmapper)
 	return out;
 }
 
-void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces)
+#include <set>
+
+void VkLightmap::Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices)
 {
 	bool newLevel = (mesh != level);
 	mesh = level;
+
+	if (newLevel)
+	{
+		UpdateAccelStructDescriptors();
+		CreateAtlasImages();
+
+		lightmapRaytrace.Reset();
+		lightmapRaytraceLast.Reset();
+	}
 
 	lightmapRaytrace.active = true;
 	lightmapRaytraceLast.active = true;
@@ -52,38 +63,56 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 	lightmapRaytrace.Clock();
 	lightmapRaytraceLast.ResetAndClock();
 
-	if (newLevel)
+#if 0
+	TArray<int> allSurfaces;
+
+	std::set<int> s;
+
+	for (auto& surface : surfaceIndices)
 	{
-		UpdateAccelStructDescriptors();
-		CreateAtlasImages();
+		s.insert(mesh->GetSurface(surface)->smoothingGroupIndex);
 	}
 
-	for (auto surface : surfaces)
+	for (int i = 0, count = level->GetSurfaceCount(); i < count; ++i)
 	{
-		surface->needsUpdate = false;
+		auto surface = level->GetSurface(i);
+		
+		if (s.find(surface->smoothingGroupIndex) != s.end())
+		{
+			allSurfaces.Push(i);
+			surface->needsUpdate = false;
+		}
 	}
+#else
+	for (auto& surface : surfaceIndices)
+	{
+		mesh->GetSurface(surface)->needsUpdate = false;
+	}
+
+	const auto& allSurfaces = surfaceIndices;
+#endif
 
 	UploadUniforms();
 
-	lastSurfaceCount = surfaces.Size();
+	lastSurfaceCount = allSurfaces.Size();
 
 	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 	{
-		RenderAtlasImage(pageIndex, surfaces);
+		RenderAtlasImage(pageIndex, allSurfaces);
 	}
 
 	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 	{
 		ResolveAtlasImage(pageIndex);
 		BlurAtlasImage(pageIndex);
-		CopyAtlasImageResult(pageIndex, surfaces);
+		CopyAtlasImageResult(pageIndex, allSurfaces);
 	}
 
 	lightmapRaytrace.Unclock();
 	lightmapRaytraceLast.Unclock();
 }
 
-void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
+void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIndices)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
@@ -105,9 +134,9 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurfac
 		cmdbuffer->bindDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, raytrace.pipelineLayout.get(), 1, raytrace.descriptorSet1.get());
 	}
 
-	for (int i = 0, count = surfaces.Size(); i < count; i++)
+	for (int i = 0, count = surfaceIndices.Size(); i < count; i++)
 	{
-		LevelMeshSurface* targetSurface = surfaces[i];
+		LevelMeshSurface* targetSurface = mesh->GetSurface(surfaceIndices[i]);
 		if (targetSurface->lightmapperAtlasPage != pageIndex)
 			continue;
 
@@ -186,7 +215,7 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurfac
 			LightmapPushConstants pc;
 			pc.LightStart = firstLight;
 			pc.LightEnd = firstLight + lightCount;
-			pc.SurfaceIndex = (int32_t)i;
+			pc.SurfaceIndex = (int32_t)std::distance((char*)mesh->GetSurface(0), (char*)targetSurface) / 288;
 			pc.LightmapOrigin = targetSurface->worldOrigin - targetSurface->worldStepX - targetSurface->worldStepY;
 			pc.LightmapStepX = targetSurface->worldStepX * viewport.width;
 			pc.LightmapStepY = targetSurface->worldStepY * viewport.height;
@@ -401,14 +430,14 @@ void VkLightmap::BlurAtlasImage(size_t pageIndex)
 	}
 }
 
-void VkLightmap::CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
+void VkLightmap::CopyAtlasImageResult(size_t pageIndex, const TArray<int>& surfaceIndices)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
 	std::vector<VkImageCopy> regions;
-	for (int i = 0, count = surfaces.Size(); i < count; i++)
+	for (int i = 0, count = surfaceIndices.Size(); i < count; i++)
 	{
-		LevelMeshSurface* surface = surfaces[i];
+		LevelMeshSurface* surface = mesh->GetSurface(surfaceIndices[i]);
 		if (surface->lightmapperAtlasPage != pageIndex)
 			continue;
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -21,7 +21,7 @@ ADD_STAT(lightmapper)
 
 CVAR(Int, lm_background_updates, 8, CVAR_NOSAVE);
 CVAR(Int, lm_max_updates, 128, CVAR_NOSAVE);
-
+CVAR(Float, lm_scale, 1.0, CVAR_NOSAVE);
 
 VkLightmap::VkLightmap(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -95,6 +95,11 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 		const auto& allSurfaces = surfaces;
 #endif
 
+		for (auto& surface : surfaces)
+		{
+			surface->needsUpdate = false; // it may have been set to false already, but lightmapper ultimately decides so
+		}
+
 		UploadUniforms();
 
 		lastSurfaceCount = allSurfaces.Size();

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -30,7 +30,7 @@ VkLightmap::~VkLightmap()
 		lights.Buffer->Unmap();
 }
 
-void VkLightmap::Raytrace(LevelMesh* level)
+void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces)
 {
 	bool newLevel = (mesh != level);
 	mesh = level;
@@ -45,7 +45,7 @@ void VkLightmap::Raytrace(LevelMesh* level)
 
 	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 	{
-		RenderAtlasImage(pageIndex);
+		RenderAtlasImage(pageIndex, surfaces);
 	}
 
 	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
@@ -56,7 +56,7 @@ void VkLightmap::Raytrace(LevelMesh* level)
 	}
 }
 
-void VkLightmap::RenderAtlasImage(size_t pageIndex)
+void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
@@ -78,9 +78,9 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex)
 		cmdbuffer->bindDescriptorSet(VK_PIPELINE_BIND_POINT_GRAPHICS, raytrace.pipelineLayout.get(), 1, raytrace.descriptorSet1.get());
 	}
 
-	for (int i = 0, count = mesh->GetSurfaceCount(); i < count; i++)
+	for (int i = 0, count = surfaces.Size(); i < count; i++)
 	{
-		LevelMeshSurface* targetSurface = mesh->GetSurface(i);
+		LevelMeshSurface* targetSurface = surfaces[i];
 		if (targetSurface->lightmapperAtlasPage != pageIndex)
 			continue;
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -53,7 +53,6 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 {
 	bool newLevel = (mesh != level);
 	mesh = level;
-
 	if (newLevel)
 	{
 		UpdateAccelStructDescriptors();
@@ -62,62 +61,65 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 		lightmapRaytraceLast.Reset();
 	}
 
-	lightmapRaytrace.active = true;
-	lightmapRaytraceLast.active = true;
+	if (surfaces.Size())
+	{
+		lightmapRaytrace.active = true;
+		lightmapRaytraceLast.active = true;
 
-	lightmapRaytrace.Clock();
-	lightmapRaytraceLast.ResetAndClock();
+		lightmapRaytrace.Clock();
+		lightmapRaytraceLast.ResetAndClock();
 
-	CreateAtlasImages(surfaces);
+		CreateAtlasImages(surfaces);
 
 #if 0 // SmoothGroups
-	TArray<int> allSurfaces;
+		TArray<int> allSurfaces;
 
-	std::set<int> s;
+		std::set<int> s;
 
-	for (auto& surface : surfaceIndices)
-	{
-		s.insert(mesh->GetSurface(surface)->smoothingGroupIndex);
-	}
-
-	for (int i = 0, count = level->GetSurfaceCount(); i < count; ++i)
-	{
-		auto surface = level->GetSurface(i);
-		
-		if (s.find(surface->smoothingGroupIndex) != s.end())
+		for (auto& surface : surfaceIndices)
 		{
-			allSurfaces.Push(i);
-			surface->needsUpdate = false;
+			s.insert(mesh->GetSurface(surface)->smoothingGroupIndex);
 		}
-	}
+
+		for (int i = 0, count = level->GetSurfaceCount(); i < count; ++i)
+		{
+			auto surface = level->GetSurface(i);
+
+			if (s.find(surface->smoothingGroupIndex) != s.end())
+			{
+				allSurfaces.Push(i);
+				surface->needsUpdate = false;
+			}
+		}
 #else
-	const auto& allSurfaces = surfaces;
+		const auto& allSurfaces = surfaces;
 #endif
 
-	UploadUniforms();
+		UploadUniforms();
 
-	lastSurfaceCount = allSurfaces.Size();
+		lastSurfaceCount = allSurfaces.Size();
 
-	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
-	{
-		if (atlasImages[pageIndex].pageMaxX && atlasImages[pageIndex].pageMaxY)
+		for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 		{
-			RenderAtlasImage(pageIndex, allSurfaces);
+			if (atlasImages[pageIndex].pageMaxX && atlasImages[pageIndex].pageMaxY)
+			{
+				RenderAtlasImage(pageIndex, allSurfaces);
+			}
 		}
-	}
 
-	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
-	{
-		if (atlasImages[pageIndex].pageMaxX && atlasImages[pageIndex].pageMaxY)
+		for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 		{
-			ResolveAtlasImage(pageIndex);
-			BlurAtlasImage(pageIndex);
-			CopyAtlasImageResult(pageIndex, allSurfaces);
+			if (atlasImages[pageIndex].pageMaxX && atlasImages[pageIndex].pageMaxY)
+			{
+				ResolveAtlasImage(pageIndex);
+				BlurAtlasImage(pageIndex);
+				CopyAtlasImageResult(pageIndex, allSurfaces);
+			}
 		}
-	}
 
-	lightmapRaytrace.Unclock();
-	lightmapRaytraceLast.Unclock();
+		lightmapRaytrace.Unclock();
+		lightmapRaytraceLast.Unclock();
+	}
 }
 
 void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
@@ -271,7 +273,7 @@ void VkLightmap::CreateAtlasImages(const TArray<LevelMeshSurface*>& surfaces)
 		LevelMeshSurface* surface = surfaces[i];
 	//for (int i = 0, count = mesh->GetSurfaceCount(); i < count; i++)
 	//{
-		//LevelMeshSurface* surface = mesh->GetSurface(i);
+	//	LevelMeshSurface* surface = mesh->GetSurface(i);
 
 		auto result = packer.insert(surface->texWidth + 2, surface->texHeight + 2);
 		surface->lightmapperAtlasX = result.pos.x + 1;

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -31,13 +31,13 @@ VkLightmap::~VkLightmap()
 }
 
 static int lastSurfaceCount;
+static glcycle_t lightmapRaytrace;
+static glcycle_t lightmapRaytraceLast;
 
 ADD_STAT(lightmapper)
 {
 	FString out;
-	
-	out.Format("Last batch surface count: %d", lastSurfaceCount);
-
+	out.Format("last: %.3fms\ntotal: %3.fms\nLast batch surface count: %d", lightmapRaytraceLast.TimeMS(), lightmapRaytrace.TimeMS(), lastSurfaceCount);
 	return out;
 }
 
@@ -45,6 +45,12 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 {
 	bool newLevel = (mesh != level);
 	mesh = level;
+
+	lightmapRaytrace.active = true;
+	lightmapRaytraceLast.active = true;
+
+	lightmapRaytrace.Clock();
+	lightmapRaytraceLast.ResetAndClock();
 
 	if (newLevel)
 	{
@@ -72,6 +78,9 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 		BlurAtlasImage(pageIndex);
 		CopyAtlasImageResult(pageIndex, surfaces);
 	}
+
+	lightmapRaytrace.Unclock();
+	lightmapRaytraceLast.Unclock();
 }
 
 void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -30,6 +30,17 @@ VkLightmap::~VkLightmap()
 		lights.Buffer->Unmap();
 }
 
+static int lastSurfaceCount;
+
+ADD_STAT(lightmapper)
+{
+	FString out;
+	
+	out.Format("Last batch surface count: %d", lastSurfaceCount);
+
+	return out;
+}
+
 void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces)
 {
 	bool newLevel = (mesh != level);
@@ -41,7 +52,14 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 		CreateAtlasImages();
 	}
 
+	for (auto surface : surfaces)
+	{
+		surface->needsUpdate = false;
+	}
+
 	UploadUniforms();
+
+	lastSurfaceCount = surfaces.Size();
 
 	for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 	{
@@ -52,7 +70,7 @@ void VkLightmap::Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& sur
 	{
 		ResolveAtlasImage(pageIndex);
 		BlurAtlasImage(pageIndex);
-		CopyAtlasImageResult(pageIndex);
+		CopyAtlasImageResult(pageIndex, surfaces);
 	}
 }
 
@@ -374,14 +392,14 @@ void VkLightmap::BlurAtlasImage(size_t pageIndex)
 	}
 }
 
-void VkLightmap::CopyAtlasImageResult(size_t pageIndex)
+void VkLightmap::CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces)
 {
 	LightmapImage& img = atlasImages[pageIndex];
 
 	std::vector<VkImageCopy> regions;
-	for (int i = 0, count = mesh->GetSurfaceCount(); i < count; i++)
+	for (int i = 0, count = surfaces.Size(); i < count; i++)
 	{
-		LevelMeshSurface* surface = mesh->GetSurface(i);
+		LevelMeshSurface* surface = surfaces[i];
 		if (surface->lightmapperAtlasPage != pageIndex)
 			continue;
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
@@ -90,17 +90,17 @@ public:
 	VkLightmap(VulkanRenderDevice* fb);
 	~VkLightmap();
 
-	void Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices);
+	void Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces);
 
 private:
 	void UpdateAccelStructDescriptors();
 
 	void UploadUniforms();
-	void CreateAtlasImages(const TArray<int>& surfaceIndices);
-	void RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIndices);
+	void CreateAtlasImages(const TArray<LevelMeshSurface*>& surfaces);
+	void RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
 	void ResolveAtlasImage(size_t pageIndex);
 	void BlurAtlasImage(size_t pageIndex);
-	void CopyAtlasImageResult(size_t pageIndex, const TArray<int>& surfaceIndices);
+	void CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
 
 	LightmapImage CreateImage(int width, int height);
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
@@ -55,6 +55,10 @@ struct LightmapImage
 		std::unique_ptr<VulkanFramebuffer> Framebuffer;
 		std::unique_ptr<VulkanDescriptorSet> DescriptorSet[2];
 	} blur;
+
+	// how much of the page is used?
+	uint16_t pageMaxX = 0;
+	uint16_t pageMaxY = 0;
 };
 
 struct SceneVertex
@@ -92,7 +96,7 @@ private:
 	void UpdateAccelStructDescriptors();
 
 	void UploadUniforms();
-	void CreateAtlasImages();
+	void CreateAtlasImages(const TArray<int>& surfaceIndices);
 	void RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIndices);
 	void ResolveAtlasImage(size_t pageIndex);
 	void BlurAtlasImage(size_t pageIndex);

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
@@ -86,14 +86,14 @@ public:
 	VkLightmap(VulkanRenderDevice* fb);
 	~VkLightmap();
 
-	void Raytrace(LevelMesh* level);
+	void Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces);
 
 private:
 	void UpdateAccelStructDescriptors();
 
 	void UploadUniforms();
 	void CreateAtlasImages();
-	void RenderAtlasImage(size_t pageIndex);
+	void RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
 	void ResolveAtlasImage(size_t pageIndex);
 	void BlurAtlasImage(size_t pageIndex);
 	void CopyAtlasImageResult(size_t pageIndex);

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
@@ -86,17 +86,17 @@ public:
 	VkLightmap(VulkanRenderDevice* fb);
 	~VkLightmap();
 
-	void Raytrace(LevelMesh* level, const TArray<LevelMeshSurface*>& surfaces);
+	void Raytrace(LevelMesh* level, const TArray<int>& surfaceIndices);
 
 private:
 	void UpdateAccelStructDescriptors();
 
 	void UploadUniforms();
 	void CreateAtlasImages();
-	void RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
+	void RenderAtlasImage(size_t pageIndex, const TArray<int>& surfaceIndices);
 	void ResolveAtlasImage(size_t pageIndex);
 	void BlurAtlasImage(size_t pageIndex);
-	void CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
+	void CopyAtlasImageResult(size_t pageIndex, const TArray<int>& surfaceIndices);
 
 	LightmapImage CreateImage(int width, int height);
 

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.h
@@ -96,7 +96,7 @@ private:
 	void RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
 	void ResolveAtlasImage(size_t pageIndex);
 	void BlurAtlasImage(size_t pageIndex);
-	void CopyAtlasImageResult(size_t pageIndex);
+	void CopyAtlasImageResult(size_t pageIndex, const TArray<LevelMeshSurface*>& surfaces);
 
 	LightmapImage CreateImage(int width, int height);
 

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -557,15 +557,15 @@ void VulkanRenderDevice::SetLevelMesh(LevelMesh* mesh)
 	}
 }
 
-void VulkanRenderDevice::UpdateLightmaps(const TArray<int>& surfaceIndices)
+void VulkanRenderDevice::UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces)
 {
-	if (surfaceIndices.Size() > 0)
+	if (surfaces.Size() > 0)
 	{
 		auto levelMesh = lastMesh; // There's nothing more permanent than a temporary solution
 
 		if (levelMesh)
 		{
-			GetLightmap()->Raytrace(levelMesh, surfaceIndices);
+			GetLightmap()->Raytrace(levelMesh, surfaces);
 		}
 	}
 }

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -529,17 +529,20 @@ void VulkanRenderDevice::PrintStartupLog()
 	Printf("Min. uniform buffer offset alignment: %" PRIu64 "\n", limits.minUniformBufferOffsetAlignment);
 }
 
+LevelMesh* lastMesh = nullptr; // Temp hack; Since this function is called every frame we only want to do this once
+
 void VulkanRenderDevice::SetLevelMesh(LevelMesh* mesh)
 {
 	mRaytrace->SetLevelMesh(mesh);
 
-	static LevelMesh* lastMesh = nullptr; // Temp hack; Since this function is called every frame we only want to do this once
 	if (lastMesh != mesh && mesh->GetSurfaceCount() > 0)
 	{
 		lastMesh = mesh;
 
 		mesh->UpdateLightLists();
+		GetTextureManager()->CreateLightmap(mesh->LMTextureSize, mesh->LMTextureCount);
 
+#if 0 // full lightmap generation
 		TArray<LevelMeshSurface*> surfaces;
 		surfaces.Reserve(mesh->GetSurfaceCount());
 		for (unsigned i = 0, count = mesh->GetSurfaceCount(); i < count; ++i)
@@ -547,8 +550,23 @@ void VulkanRenderDevice::SetLevelMesh(LevelMesh* mesh)
 			surfaces[i] = mesh->GetSurface(i);
 		}
 
-		GetTextureManager()->CreateLightmap(mesh->LMTextureSize, mesh->LMTextureCount);
 		GetLightmap()->Raytrace(mesh, surfaces);
+#else
+		GetLightmap()->Raytrace(mesh, {});
+#endif
+	}
+}
+
+void VulkanRenderDevice::UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces)
+{
+	if (surfaces.Size() > 0)
+	{
+		auto levelMesh = lastMesh; // There's nothing more permanent than a temporary solution
+
+		if (levelMesh)
+		{
+			GetLightmap()->Raytrace(levelMesh, surfaces);
+		}
 	}
 }
 

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -540,8 +540,15 @@ void VulkanRenderDevice::SetLevelMesh(LevelMesh* mesh)
 
 		mesh->UpdateLightLists();
 
+		TArray<LevelMeshSurface*> surfaces;
+		surfaces.Reserve(mesh->GetSurfaceCount());
+		for (unsigned i = 0, count = mesh->GetSurfaceCount(); i < count; ++i)
+		{
+			surfaces[i] = mesh->GetSurface(i);
+		}
+
 		GetTextureManager()->CreateLightmap(mesh->LMTextureSize, mesh->LMTextureCount);
-		GetLightmap()->Raytrace(mesh);
+		GetLightmap()->Raytrace(mesh, surfaces);
 	}
 }
 

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -557,15 +557,15 @@ void VulkanRenderDevice::SetLevelMesh(LevelMesh* mesh)
 	}
 }
 
-void VulkanRenderDevice::UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces)
+void VulkanRenderDevice::UpdateLightmaps(const TArray<int>& surfaceIndices)
 {
-	if (surfaces.Size() > 0)
+	if (surfaceIndices.Size() > 0)
 	{
 		auto levelMesh = lastMesh; // There's nothing more permanent than a temporary solution
 
 		if (levelMesh)
 		{
-			GetLightmap()->Raytrace(levelMesh, surfaces);
+			GetLightmap()->Raytrace(levelMesh, surfaceIndices);
 		}
 	}
 }

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -63,7 +63,7 @@ public:
 	void AmbientOccludeScene(float m5) override;
 	void SetSceneRenderTarget(bool useSSAO) override;
 	void SetLevelMesh(LevelMesh* mesh) override;
-	void UpdateLightmaps(const TArray<int>& surfaceIndices) override;
+	void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) override;
 	void SetShadowMaps(const TArray<float>& lights, hwrenderer::LevelAABBTree* tree, bool newTree) override;
 	void SetSaveBuffers(bool yes) override;
 	void ImageTransitionScene(bool unknown) override;

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -63,6 +63,7 @@ public:
 	void AmbientOccludeScene(float m5) override;
 	void SetSceneRenderTarget(bool useSSAO) override;
 	void SetLevelMesh(LevelMesh* mesh) override;
+	void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) override;
 	void SetShadowMaps(const TArray<float>& lights, hwrenderer::LevelAABBTree* tree, bool newTree) override;
 	void SetSaveBuffers(bool yes) override;
 	void ImageTransitionScene(bool unknown) override;

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -63,7 +63,7 @@ public:
 	void AmbientOccludeScene(float m5) override;
 	void SetSceneRenderTarget(bool useSSAO) override;
 	void SetLevelMesh(LevelMesh* mesh) override;
-	void UpdateLightmaps(const TArray<LevelMeshSurface*>& surfaces) override;
+	void UpdateLightmaps(const TArray<int>& surfaceIndices) override;
 	void SetShadowMaps(const TArray<float>& lights, hwrenderer::LevelAABBTree* tree, bool newTree) override;
 	void SetSaveBuffers(bool yes) override;
 	void ImageTransitionScene(bool unknown) override;

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -23,6 +23,18 @@ CCMD(dumplevelmesh)
 	}
 }
 
+CCMD(invalidatelightmap)
+{
+	int count = 0;
+	for (auto& surface : level.levelMesh->Surfaces)
+	{
+		if (!surface.needsUpdate)
+			++count;
+		surface.needsUpdate = true;
+	}
+	Printf("Marked %d out of %d surfaces for update.\n", count, level.levelMesh->Surfaces.Size());
+}
+
 DoomLevelMesh::DoomLevelMesh(FLevelLocals &doomMap)
 {
 	SunColor = doomMap.SunColor; // TODO keep only one copy?

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -35,6 +35,8 @@ CCMD(invalidatelightmap)
 	Printf("Marked %d out of %d surfaces for update.\n", count, level.levelMesh->Surfaces.Size());
 }
 
+EXTERN_CVAR(Float, lm_scale);
+
 DoomLevelMesh::DoomLevelMesh(FLevelLocals &doomMap)
 {
 	SunColor = doomMap.SunColor; // TODO keep only one copy?
@@ -1099,6 +1101,8 @@ void DoomLevelMesh::BuildSurfaceParams(int lightMapTextureWidth, int lightMapTex
 	{
 		surface.sampleDimension = LightmapSampleDistance;
 	}
+
+	surface.sampleDimension = uint16_t(max(int(roundf(float(surface.sampleDimension) / max(1.0f / 4, float(lm_scale)))), 1));
 
 	{
 		// Round to nearest power of two

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -98,6 +98,15 @@ DoomLevelMesh::DoomLevelMesh(FLevelLocals &doomMap)
 	BindLightmapSurfacesToGeometry(doomMap);
 
 	Collision = std::make_unique<TriangleMeshShape>(MeshVertices.Data(), MeshVertices.Size(), MeshElements.Data(), MeshElements.Size());
+
+	// Runtime stuff
+	for (auto& surface : Surfaces)
+	{
+		if ((surface.Type == ST_FLOOR || surface.Type == ST_CEILING) && surface.ControlSector)
+		{
+			XFloorToSurface[surface.ControlSector].Push(&surface);
+		}
+	}
 }
 
 void DoomLevelMesh::CreatePortals()

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -369,8 +369,6 @@ void DoomLevelMesh::BindLightmapSurfacesToGeometry(FLevelLocals& doomMap)
 	{
 		surface.TexCoords = (float*)&LightmapUvs[surface.startUvIndex];
 
-		surface.LightmapNum = surface.atlasPageIndex;
-
 		if (surface.Type == ST_FLOOR || surface.Type == ST_CEILING)
 		{
 			surface.Subsector = &doomMap.subsectors[surface.typeIndex];

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -104,7 +104,7 @@ DoomLevelMesh::DoomLevelMesh(FLevelLocals &doomMap)
 	{
 		if ((surface.Type == ST_FLOOR || surface.Type == ST_CEILING) && surface.ControlSector)
 		{
-			XFloorToSurface[surface.ControlSector].Push(&surface);
+			XFloorToSurface[surface.Subsector->sector].Push(&surface);
 		}
 	}
 }

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -16,10 +16,9 @@ struct FLevelLocals;
 
 struct DoomLevelMeshSurface : public LevelMeshSurface
 {
-	subsector_t* Subsector;
-	side_t* Side;
-	sector_t* ControlSector;
-	uint32_t LightmapNum; // To do: same as atlasPageIndex. Delete one of them!
+	subsector_t* Subsector = nullptr;
+	side_t* Side = nullptr;
+	sector_t* ControlSector = nullptr;
 	float* TexCoords;
 };
 

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -27,6 +27,9 @@ class DoomLevelMesh : public LevelMesh
 {
 public:
 	DoomLevelMesh(FLevelLocals &doomMap);
+	
+	void CreatePortals();
+	void DumpMesh(const FString& objFilename, const FString& mtlFilename) const;
 
 	bool TraceSky(const FVector3& start, FVector3 direction, float dist)
 	{
@@ -40,17 +43,15 @@ public:
 	LevelMeshSurface* GetSurface(int index) override { return &Surfaces[index]; }
 	int GetSurfaceCount() override { return Surfaces.Size(); }
 
+
 	TArray<DoomLevelMeshSurface> Surfaces;
 	std::vector<std::unique_ptr<LevelMeshLight>> Lights;
 	TArray<FVector2> LightmapUvs;
-
 	static_assert(alignof(FVector2) == alignof(float[2]) && sizeof(FVector2) == sizeof(float) * 2);
 
-	void DumpMesh(const FString& objFilename, const FString& mtlFilename) const;
+	// runtime utility variables
+	TMap<sector_t*, TArray<DoomLevelMeshSurface*>> XFloorToSurface;
 
-	void SetupLightmapUvs();
-
-	void CreatePortals();
 private:
 	void CreateSubsectorSurfaces(FLevelLocals &doomMap);
 	void CreateCeilingSurface(FLevelLocals &doomMap, subsector_t *sub, sector_t *sector, int typeIndex, bool is3DFloor);
@@ -61,6 +62,7 @@ private:
 	void SetSubsectorLightmap(DoomLevelMeshSurface* surface);
 	void SetSideLightmap(DoomLevelMeshSurface* surface);
 
+	void SetupLightmapUvs();
 	void PropagateLight(const LevelMeshLight* light, std::set<LevelMeshPortal, RecursivePortalComparator>& touchedPortals, int lightPropagationRecursiveDepth);
 	void CreateLightList();
 

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -51,7 +51,6 @@
 #include "hwrenderer/scene/hw_drawcontext.h"
 #include "hw_vrmodes.h"
 
-EXTERN_CVAR(Int, lm_background_updates);
 EXTERN_CVAR(Bool, cl_capfps)
 extern bool NoInterpolateView;
 
@@ -97,34 +96,6 @@ void CollectLights(FLevelLocals* Level)
 	}
 }
 
-void UpdateLightmaps(DFrameBuffer* screen, FRenderState& RenderState)
-{
-
-	// Lightmapping stuff
-	auto& list = RenderState.GetVisibleSurfaceList();
-	auto size = RenderState.GetVisibleSurfaceListCount();
-
-	list.Resize(min(list.Size(), unsigned(size)));
-
-	if (size < lm_background_updates)
-	{
-		int index = 0;
-		for (auto& e : level.levelMesh->Surfaces)
-		{
-			if (e.needsUpdate)
-			{
-				list.Push(index);
-
-				if (list.Size() >= lm_background_updates)
-					break;
-			}
-			++index;
-		}
-	}
-
-	screen->UpdateLightmaps(list);
-}
-
 //-----------------------------------------------------------------------------
 //
 // Renders one viewpoint in a scene
@@ -152,7 +123,6 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 		screen->mShadowMap->SetCollectLights(nullptr);
 	}
 
-	RenderState.ClearVisibleSurfaceList();
 	screen->SetLevelMesh(camera->Level->levelMesh);
 
 	static HWDrawContext mainthread_drawctx;
@@ -225,8 +195,6 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 		if (eyeCount - eye_ix > 1)
 			screen->NextEye(eyeCount);
 	}
-
-	UpdateLightmaps(screen, RenderState);
 
 	return mainvp.sector;
 }

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -124,6 +124,7 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 		screen->mShadowMap->SetCollectLights(nullptr);
 	}
 
+	RenderState.ClearVisibleSurfaceList();
 	screen->SetLevelMesh(camera->Level->levelMesh);
 
 	static HWDrawContext mainthread_drawctx;
@@ -196,6 +197,8 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 		if (eyeCount - eye_ix > 1)
 			screen->NextEye(eyeCount);
 	}
+
+	screen->UpdateLightmaps(RenderState.GetVisibleSurfaceList());
 
 	return mainvp.sector;
 }

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -97,6 +97,33 @@ void CollectLights(FLevelLocals* Level)
 	}
 }
 
+void UpdateLightmaps(DFrameBuffer* screen, FRenderState& RenderState)
+{
+
+	// Lightmapping stuff
+	auto& list = RenderState.GetVisibleSurfaceList();
+	auto size = RenderState.GetVisibleSurfaceListCount();
+
+	list.Resize(min(list.Size(), unsigned(size)));
+
+	if (size < lm_background_updates)
+	{
+		int index = 0;
+		for (auto& e : level.levelMesh->Surfaces)
+		{
+			if (e.needsUpdate)
+			{
+				list.Push(index);
+
+				if (list.Size() >= lm_background_updates)
+					break;
+			}
+			++index;
+		}
+	}
+
+	screen->UpdateLightmaps(list);
+}
 
 //-----------------------------------------------------------------------------
 //
@@ -199,24 +226,7 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 			screen->NextEye(eyeCount);
 	}
 
-	auto& list = RenderState.GetVisibleSurfaceList();
-	if (list.Size() < lm_background_updates)
-	{
-		int index = 0;
-		for (auto& e : level.levelMesh->Surfaces)
-		{
-			if (e.needsUpdate)
-			{
-				list.Push(index);
-
-				if(list.Size() >= lm_background_updates)
-					break;
-			}
-			++index;
-		}
-	}
-
-	screen->UpdateLightmaps(list);
+	UpdateLightmaps(screen, RenderState);
 
 	return mainvp.sector;
 }

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -200,7 +200,7 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 	}
 
 	auto& list = RenderState.GetVisibleSurfaceList();
-	if (list.Size() <= lm_background_updates)
+	if (list.Size() < lm_background_updates)
 	{
 		int index = 0;
 		for (auto& e : level.levelMesh->Surfaces)

--- a/src/rendering/hwrenderer/hw_vertexbuilder.cpp
+++ b/src/rendering/hwrenderer/hw_vertexbuilder.cpp
@@ -243,7 +243,7 @@ static int CreateIndexedSectorVerticesLM(FRenderState& renderstate, sector_t* se
 		if (lightmap && lightmap->Type != ST_UNKNOWN) // lightmap may be missing if the subsector is degenerate triangle
 		{
 			float* luvs = lightmap->TexCoords;
-			int lindex = lightmap->LightmapNum;
+			int lindex = lightmap->atlasPageIndex;
 			for (unsigned int j = 0; j < sub->numlines; j++)
 			{
 				SetFlatVertex(vbo_shadowdata[vi + pos], sub->firstline[j].v1, plane, luvs[j * 2], luvs[j * 2 + 1], lindex);

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -867,17 +867,15 @@ void UpdateLightmaps(DFrameBuffer* screen, FRenderState& RenderState)
 
 	if (size < lm_background_updates)
 	{
-		int index = 0;
 		for (auto& e : level.levelMesh->Surfaces)
 		{
 			if (e.needsUpdate)
 			{
-				list.Push(index);
+				list.Push(&e);
 
 				if (list.Size() >= lm_background_updates)
 					break;
 			}
-			++index;
 		}
 	}
 

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -507,11 +507,14 @@ void HWFlat::ProcessSector(HWDrawInfo *di, FRenderState& state, sector_t * front
 
 	const auto* lm = &sector->Level->levelMesh->Surfaces[0]; // temporay hack on top of a temporary hack
 
-	for (auto& subsector : section->subsectors)
+	for (int i = 0, count = sector->subsectorcount; i < count; ++i)
 	{
-		if (auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0])
+		for (int plane = 0; plane < 2; ++plane)
 		{
-			state.PushVisibleSurface(lightmap - lm, lightmap);
+			if (auto lightmap = sector->subsectors[i]->lightmap[plane][0])
+			{
+				state.PushVisibleSurface(lightmap - lm, lightmap);
+			}
 		}
 	}
 

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -194,7 +194,11 @@ void HWFlat::DrawSubsectors(HWDrawInfo *di, FRenderState &state)
 
 	for (auto& subsector : section->subsectors)
 	{
-		state.PushVisibleSurface(subsector->lightmap[ceiling ? 1 : 0][0]);
+		auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0];
+		if (lightmap)
+		{
+			state.PushVisibleSurface(lightmap - &subsector->sector->Level->levelMesh->Surfaces[0], lightmap);
+		}
 	}
 
 	state.DrawIndexed(DT_Triangles, iboindex + section->vertexindex, section->vertexcount);

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -192,6 +192,10 @@ void HWFlat::DrawSubsectors(HWDrawInfo *di, FRenderState &state)
 	}
 	state.SetLightIndex(dynlightindex);
 
+	for (auto& subsector : section->subsectors)
+	{
+		state.PushVisibleSurface(subsector->lightmap[ceiling ? 1 : 0][0]);
+	}
 
 	state.DrawIndexed(DT_Triangles, iboindex + section->vertexindex, section->vertexcount);
 	flatvertices += section->vertexcount;

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -191,28 +191,6 @@ void HWFlat::DrawSubsectors(HWDrawInfo *di, FRenderState &state)
 		SetupLights(di, state, section->lighthead, lightdata, sector->PortalGroup);
 	}
 	state.SetLightIndex(dynlightindex);
-
-	const auto* lm = &sector->Level->levelMesh->Surfaces[0]; // temporay hack on top of a temporary hack
-
-	for (auto& subsector : section->subsectors)
-	{
-		if (auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0])
-		{
-			state.PushVisibleSurface(lightmap - lm, lightmap);
-		}
-	}
-
-	if (auto subsectors = sector->Level->levelMesh->XFloorToSurface.CheckKey(sector))
-	{
-		for (auto* surface : *subsectors)
-		{
-			if (surface)
-			{
-				state.PushVisibleSurface(surface - lm, surface);
-			}
-		}
-	}
-
 	state.DrawIndexed(DT_Triangles, iboindex + section->vertexindex, section->vertexcount);
 	flatvertices += section->vertexcount;
 	flatprimitives++;
@@ -522,6 +500,31 @@ void HWFlat::ProcessSector(HWDrawInfo *di, FRenderState& state, sector_t * front
 	uint8_t sink;
 	uint8_t &srf = hacktype? sink : di->section_renderflags[di->Level->sections.SectionIndex(section)];
     const auto &vp = di->Viewpoint;
+
+	//
+	// Lightmaps
+	//
+
+	const auto* lm = &sector->Level->levelMesh->Surfaces[0]; // temporay hack on top of a temporary hack
+
+	for (auto& subsector : section->subsectors)
+	{
+		if (auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0])
+		{
+			state.PushVisibleSurface(lightmap - lm, lightmap);
+		}
+	}
+
+	if (auto subsectors = sector->Level->levelMesh->XFloorToSurface.CheckKey(sector))
+	{
+		for (auto* surface : *subsectors)
+		{
+			if (surface)
+			{
+				state.PushVisibleSurface(surface - lm, surface);
+			}
+		}
+	}
 
 	//
 	//

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -192,12 +192,24 @@ void HWFlat::DrawSubsectors(HWDrawInfo *di, FRenderState &state)
 	}
 	state.SetLightIndex(dynlightindex);
 
+	const auto* lm = &sector->Level->levelMesh->Surfaces[0]; // temporay hack on top of a temporary hack
+
 	for (auto& subsector : section->subsectors)
 	{
-		auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0];
-		if (lightmap)
+		if (auto lightmap = subsector->lightmap[ceiling ? 1 : 0][0])
 		{
-			state.PushVisibleSurface(lightmap - &subsector->sector->Level->levelMesh->Surfaces[0], lightmap);
+			state.PushVisibleSurface(lightmap - lm, lightmap);
+		}
+	}
+
+	if (auto subsectors = sector->Level->levelMesh->XFloorToSurface.CheckKey(sector))
+	{
+		for (auto* surface : *subsectors)
+		{
+			if (surface)
+			{
+				state.PushVisibleSurface(surface - lm, surface);
+			}
 		}
 	}
 

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -1019,7 +1019,7 @@ bool HWWall::SetWallCoordinates(seg_t * seg, FTexCoordInfo *tci, float textureto
 	if (lightmap && lightmap->Type != ST_UNKNOWN)
 	{
 		srclightuv = (texcoord*)lightmap->TexCoords;
-		lindex = (float)lightmap->LightmapNum;
+		lindex = (float)lightmap->atlasPageIndex;
 	}
 	else
 	{
@@ -1725,7 +1725,7 @@ void HWWall::BuildFFBlock(HWDrawInfo *di, FRenderState& state, seg_t * seg, F3DF
 		if (lightmap && lightmap->Type != ST_UNKNOWN)
 		{
 			srclightuv = (texcoord*)lightmap->TexCoords;
-			lindex = (float)lightmap->LightmapNum;
+			lindex = (float)lightmap->atlasPageIndex;
 		}
 		else
 		{

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -347,7 +347,11 @@ void HWWall::DrawWall(HWDrawInfo *di, FRenderState &state, bool translucent)
 		MakeVertices(di, state, !!(flags & HWWall::HWF_TRANSLUCENT));
 	}
 
-	state.PushVisibleSurface(lightmap);
+	if (lightmap)
+	{
+		state.PushVisibleSurface(lightmap - &seg->Subsector->sector->Level->levelMesh->Surfaces[0], lightmap);
+	}
+
 	state.SetNormal(glseg.Normal());
 	if (!translucent)
 	{

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -347,6 +347,7 @@ void HWWall::DrawWall(HWDrawInfo *di, FRenderState &state, bool translucent)
 		MakeVertices(di, state, !!(flags & HWWall::HWF_TRANSLUCENT));
 	}
 
+	state.PushVisibleSurface(lightmap);
 	state.SetNormal(glseg.Normal());
 	if (!translucent)
 	{

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -347,11 +347,6 @@ void HWWall::DrawWall(HWDrawInfo *di, FRenderState &state, bool translucent)
 		MakeVertices(di, state, !!(flags & HWWall::HWF_TRANSLUCENT));
 	}
 
-	if (lightmap)
-	{
-		state.PushVisibleSurface(lightmap - &seg->Subsector->sector->Level->levelMesh->Surfaces[0], lightmap);
-	}
-
 	state.SetNormal(glseg.Normal());
 	if (!translucent)
 	{
@@ -1270,6 +1265,10 @@ void HWWall::DoTexture(HWDrawInfo *di, FRenderState& state, int _type,seg_t * se
 	if (seg->sidedef->lightmap && type >= RENDERWALL_TOP && type <= RENDERWALL_BOTTOM)
 	{
 		lightmap = seg->sidedef->lightmap[type - RENDERWALL_TOP];
+		if (lightmap)
+		{
+			state.PushVisibleSurface(lightmap - &seg->Subsector->sector->Level->levelMesh->Surfaces[0], lightmap);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Allows for partial lightmap updates. The lightmapper has high priority for surfaces visible on screen, otherwise it runs "background tasks" updating handful of surfaces that need updating.


CVARs:
**lm_scale** - multiplier for lightmap resolution of every surface. There is a hardcoded bottom limit of 0.25
**lm_background_updates 8** - How many lightmap surfaces should be progressed in the background per frame
**lm_max_updates 128** - How many on-screen surfaces can be updated per frame

CCMDs:
invalidatelightmaps
stat lightmapper
