### PR TITLE
Optimize which surfaces are passed to lightmapper

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_levelmesh.h
+++ b/src/common/rendering/hwrenderer/data/hw_levelmesh.h
@@ -92,6 +92,10 @@ struct LevelMeshSurface
 	int lightmapperAtlasY = -1;
 };
 
+inline float IsInFrontOfPlane(const FVector4& plane, const FVector3& point)
+{
+	return (plane.X * point.X + plane.Y * point.Y + plane.Z * point.Z) >= plane.W;
+}
 
 struct LevelMeshSmoothingGroup
 {

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -741,7 +741,7 @@ public:
 
 	inline void PushVisibleSurface(LevelMeshSurface* surface)
 	{
-		if (surface->needsUpdate) // TODO atomic? 
+		if (surface->needsUpdate && !surface->portalIndex && !surface->bSky) // TODO atomic?
 		{
 			auto index = mActiveLightmapSurfaceBufferIndex.fetch_add(1);
 			if (index < mActiveLightmapSurfacesBuffer.Size())

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -126,6 +126,9 @@ void VkLightmap::RenderAtlasImage(size_t pageIndex, const TArray<LevelMeshSurfac
 		if (targetSurface->lightmapperAtlasPage != pageIndex)
 			continue;
 
+		if (targetSurface->LightList.empty() && (targetSurface->plane.XYZ() | mesh->SunDirection) < 0.0f) // No lights, no sun //TODO fill the area with black pixels skipping blur and resolve pass
+			continue;
+
 		VkViewport viewport = {};
 		viewport.maxDepth = 1;
 		viewport.x = (float)targetSurface->lightmapperAtlasX - 1;

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -699,17 +699,18 @@ void DoomLevelMesh::CreateSideSurfaces(FLevelLocals &doomMap, side_t *side)
 void DoomLevelMesh::CreateFloorSurface(FLevelLocals &doomMap, subsector_t *sub, sector_t *sector, sector_t *controlSector, int typeIndex)
 {
 	DoomLevelMeshSurface surf;
-	surf.bSky = IsSkySector(sector, sector_t::floor);
 
 	secplane_t plane;
 	if (!controlSector)
 	{
 		plane = sector->floorplane;
+		surf.bSky = IsSkySector(sector, sector_t::floor);
 	}
 	else
 	{
 		plane = controlSector->ceilingplane;
 		plane.FlipVert();
+		surf.bSky = false;
 	}
 
 	surf.numVerts = sub->numlines;
@@ -739,17 +740,18 @@ void DoomLevelMesh::CreateFloorSurface(FLevelLocals &doomMap, subsector_t *sub, 
 void DoomLevelMesh::CreateCeilingSurface(FLevelLocals& doomMap, subsector_t* sub, sector_t* sector, sector_t* controlSector, int typeIndex)
 {
 	DoomLevelMeshSurface surf;
-	surf.bSky = IsSkySector(sector, sector_t::ceiling);
 
 	secplane_t plane;
 	if (!controlSector)
 	{
 		plane = sector->ceilingplane;
+		surf.bSky = IsSkySector(sector, sector_t::ceiling);
 	}
 	else
 	{
 		plane = controlSector->floorplane;
 		plane.FlipVert();
+		surf.bSky = false;
 	}
 
 	surf.numVerts = sub->numlines;

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -204,6 +204,7 @@ void DoomLevelMesh::PropagateLight(const LevelMeshLight* light, std::set<LevelMe
 
 		// TODO skip any surface which isn't physically connected to the sector group in which the light resides
 		//if (light-> == surface.sectorGroup)
+		if (IsInFrontOfPlane(surface.plane, light->RelativeOrigin))
 		{
 			if (surface.portalIndex >= 0)
 			{

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -869,7 +869,7 @@ void UpdateLightmaps(DFrameBuffer* screen, FRenderState& RenderState)
 	{
 		for (auto& e : level.levelMesh->Surfaces)
 		{
-			if (e.needsUpdate && !e.bSky)
+			if (e.needsUpdate && !e.bSky && !e.portalIndex)
 			{
 				list.Push(&e);
 

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -869,7 +869,7 @@ void UpdateLightmaps(DFrameBuffer* screen, FRenderState& RenderState)
 	{
 		for (auto& e : level.levelMesh->Surfaces)
 		{
-			if (e.needsUpdate)
+			if (e.needsUpdate && !e.bSky)
 			{
 				list.Push(&e);
 


### PR DESCRIPTION
Skip sky, obviously unlit surfaces and check whether the pointlight is in front of the surface or not before adding it to the light list.