### PR TITLE
Workaround to make 3d floor side surfaces detectable

### DIFF
--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -376,9 +376,16 @@ void DoomLevelMesh::BindLightmapSurfacesToGeometry(FLevelLocals& doomMap)
 	// Runtime helper
 	for (auto& surface : Surfaces)
 	{
-		if ((surface.Type == ST_FLOOR || surface.Type == ST_CEILING) && surface.ControlSector)
+		if (surface.ControlSector)
 		{
-			XFloorToSurface[surface.Subsector->sector].Push(&surface);
+			if (surface.Type == ST_FLOOR || surface.Type == ST_CEILING)
+			{
+				XFloorToSurface[surface.Subsector->sector].Push(&surface);
+			}
+			else if (surface.Type == ST_MIDDLESIDE)
+			{
+				XFloorToSurfaceSides[surface.ControlSector].Push(&surface);
+			}
 		}
 	}
 }

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -51,7 +51,8 @@ public:
 	static_assert(alignof(FVector2) == alignof(float[2]) && sizeof(FVector2) == sizeof(float) * 2);
 
 	// runtime utility variables
-	TMap<sector_t*, TArray<DoomLevelMeshSurface*>> XFloorToSurface;
+	TMap<const sector_t*, TArray<DoomLevelMeshSurface*>> XFloorToSurface;
+	TMap<const sector_t*, TArray<DoomLevelMeshSurface*>> XFloorToSurfaceSides;
 
 private:
 	void CreateSubsectorSurfaces(FLevelLocals &doomMap);

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -527,6 +527,23 @@ void HWFlat::ProcessSector(HWDrawInfo *di, FRenderState& state, sector_t * front
 				}
 			}
 		}
+
+		if (sector->e->XFloor.ffloors.Size())
+		{
+			for (auto* floor : sector->e->XFloor.ffloors)
+			{
+				if (auto sides = sector->Level->levelMesh->XFloorToSurfaceSides.CheckKey(floor->model))
+				{
+					for (auto* surface : *sides)
+					{
+						if (surface)
+						{
+							state.PushVisibleSurface(surface);
+						}
+					}
+				}
+			}
+		}
 	}
 
 	//


### PR DESCRIPTION
I tried to find a more proper way, but that didn't work. It's a "temporary" workaround.