### PR TITLE
Bunch of lightmap stats and ccmds

### DIFF
--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -12,10 +12,13 @@ static int lastSurfaceCount;
 static glcycle_t lightmapRaytrace;
 static glcycle_t lightmapRaytraceLast;
 
+static uint32_t lastPixelCount;
+static uint32_t totalPixelCount;
+
 ADD_STAT(lightmapper)
 {
 	FString out;
-	out.Format("last: %.3fms\ntotal: %3.fms\nLast batch surface count: %d", lightmapRaytraceLast.TimeMS(), lightmapRaytrace.TimeMS(), lastSurfaceCount);
+	out.Format("last: %.3fms\ntotal: %3.fms\nLast batch surface count: %d\nLast batch pixel count: %u\nTotal pixel count: %u", lightmapRaytraceLast.TimeMS(), lightmapRaytrace.TimeMS(), lastSurfaceCount, lastPixelCount, totalPixelCount);
 	return out;
 }
 
@@ -52,6 +55,9 @@ void VkLightmap::SetLevelMesh(LevelMesh* level)
 
 	lightmapRaytrace.Reset();
 	lightmapRaytraceLast.Reset();
+	totalPixelCount = 0;
+	lastPixelCount = 0;
+	lastSurfaceCount = 0;
 }
 
 void VkLightmap::Raytrace(const TArray<LevelMeshSurface*>& surfaces)
@@ -66,14 +72,19 @@ void VkLightmap::Raytrace(const TArray<LevelMeshSurface*>& surfaces)
 
 		CreateAtlasImages(surfaces);
 
+		uint32_t pixels = 0;
+
 		for (auto& surface : surfaces)
 		{
 			surface->needsUpdate = false; // it may have been set to false already, but lightmapper ultimately decides so
+			pixels += surface->texHeight * surface->texWidth;
 		}
 
 		UploadUniforms();
 
 		lastSurfaceCount = surfaces.Size();
+		lastPixelCount = pixels;
+		totalPixelCount += pixels;
 
 		for (size_t pageIndex = 0; pageIndex < atlasImages.size(); pageIndex++)
 		{

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -77,7 +77,7 @@ void VkLightmap::Raytrace(const TArray<LevelMeshSurface*>& surfaces)
 		for (auto& surface : surfaces)
 		{
 			surface->needsUpdate = false; // it may have been set to false already, but lightmapper ultimately decides so
-			pixels += surface->texHeight * surface->texWidth;
+			pixels += surface->Area();
 		}
 
 		UploadUniforms();


### PR DESCRIPTION
`stat lightmap` shows general statistics involving the lightmap.
`stat lightmapper` now also shows pixel area statistics.
`surfaceinfo` fires ray from player's pov against the levelmesh and prints information about which surface the ray hit.

![image](https://github.com/dpjudas/VkDoom/assets/29225776/58cba1bf-1d70-4120-a4c8-878065b11174)
![image](https://github.com/dpjudas/VkDoom/assets/29225776/b535a539-e08c-4db8-8137-228f98527119)
![image](https://github.com/dpjudas/VkDoom/assets/29225776/779fd1e8-8b58-466d-aa21-a453d370be48)
