### PR TITLE
Optimize and fix surface mismatch errors

### DIFF
--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -3040,14 +3040,22 @@ void MapLoader::LoadLightmap(MapData* map)
 
 	// Load the surfaces we have lightmap data for
 
-	// TODO more optimized way:
+	const int surfaceTypes = 5; // ST_CEILING, ST_FLOOR, etc.
+	TMap<int, TArray<DoomLevelMeshSurface*>> surfaceGroups[surfaceTypes]; // Let's assume there is only a handful of 3d floor surfaces matching the same typeIndex
+
 	auto findSurfaceIndex = [&](int type, int index, const sector_t* sec) {
-		const auto& surfaces = Level->levelMesh->Surfaces;
-		for (unsigned i = 0, count = surfaces.Size(); i < count; ++i)
+		const auto* surfaces = surfaceGroups[type - 1].CheckKey(index);
+
+		if (surfaces)
 		{
-			if (surfaces[i].Type == type && surfaces[i].typeIndex == index && sec == surfaces[i].ControlSector)
+			for (unsigned i = 0, count = surfaces->Size(); i < count; ++i)
 			{
-				return i;
+				const auto surface = (*surfaces)[i];
+
+				if (surface->ControlSector == sec)
+				{
+					return Level->levelMesh->GetSurfaceIndex(surface);
+				}
 			}
 		}
 		return 0xffffffff;
@@ -3065,14 +3073,28 @@ void MapLoader::LoadLightmap(MapData* map)
 		uint16_t width, height; // in pixels
 		uint32_t pixelsOffset; // offset in pixels array
 		uint32_t uvCount, uvOffset;
+
+		DoomLevelMeshSurface* targetSurface;
 	};
 
 	TMap<DoomLevelMeshSurface*, int> detectedSurfaces;
-	TArray<SurfaceEntry> zdraySurfaces;
+	TArray<SurfaceEntry> zdraySurfaces; // TODO reserve ahead of time 'numSurfaces'
 
 	for (auto& surface : Level->levelMesh->Surfaces)
 	{
 		surface.needsUpdate = false; // let's consider everything valid until we make a mistake trying to change this surface
+
+		if (surface.Type > ST_UNKNOWN && surface.Type <= ST_FLOOR)
+		{
+			if (auto list = surfaceGroups[surface.Type - 1].CheckKey(surface.typeIndex))
+			{
+				list->Push(&surface);
+			}
+			else
+			{
+				surfaceGroups[surface.Type - 1].InsertNew(surface.typeIndex).Push(&surface);
+			}
+		}
 	}
 
 	for (uint32_t i = 0; i < numSurfaces; i++)
@@ -3090,6 +3112,16 @@ void MapLoader::LoadLightmap(MapData* map)
 		auto controlSector = getControlSector(surface.controlSector);
 
 		// Check against the internal levelmesh
+
+		if (surface.type <= ST_UNKNOWN || surface.type > ST_FLOOR)
+		{
+			errors = true;
+			if (developer >= 1)
+			{
+				Printf(PRINT_HIGH, "Lightmap lump surface index %d uses invalid type %d\n", i, surface.type);
+			}
+			continue;
+		}
 
 		if (i >= Level->levelMesh->Surfaces.Size())
 		{
@@ -3128,11 +3160,12 @@ void MapLoader::LoadLightmap(MapData* map)
 			(*ptr)++;
 			if (developer >= 1)
 			{
-				Printf(PRINT_HIGH, "Lightmap lump surface index %d is referencing surface %d (ref count: %d). Surface type:%d, typeindex:%d, controlsector:%d\n", i, Level->levelMesh->GetSurfaceIndex(levelSurface), ptr, surface.type, surface.typeIndex, surface.controlSector);
+				Printf(PRINT_HIGH, "Lightmap lump surface index %d is referencing surface %d (ref count: %d). Surface type:%d, typeindex:%d, controlsector:%d\n", i, Level->levelMesh->GetSurfaceIndex(levelSurface), *ptr, surface.type, surface.typeIndex, surface.controlSector);
 			}
 		}
 		else
 		{
+			surface.targetSurface = levelSurface;
 			detectedSurfaces.Insert(levelSurface, 1);
 			zdraySurfaces.Push(surface);
 		}
@@ -3215,7 +3248,7 @@ void MapLoader::LoadLightmap(MapData* map)
 	{
 		++index; // for debug output
 
-		auto& realSurface = Level->levelMesh->Surfaces[findSurfaceIndex(surface.type, surface.typeIndex, getControlSector(surface.controlSector))];
+		auto& realSurface = *surface.targetSurface;
 
 		// calculate pixel positions
 		const uint32_t srcPixelOffset = surface.pixelsOffset;

--- a/src/maploader/maploader.h
+++ b/src/maploader/maploader.h
@@ -305,7 +305,7 @@ public:
 	void CopySlopes();
 
 	void InitLevelMesh(MapData* map);
-	void LoadLightmap(MapData* map);
+	bool LoadLightmap(MapData* map);
 
 	void LoadLevel(MapData *map, const char *lumpname, int position);
 

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -1070,16 +1070,23 @@ void DoomLevelMesh::SetupLightmapUvs()
 {
 	LMTextureSize = 1024; // TODO cvar
 
+	for (auto& surface : Surfaces)
+	{
+		BuildSurfaceParams(LMTextureSize, LMTextureSize, surface);
+	}
+
+	BuildSmoothingGroups();
+}
+
+void DoomLevelMesh::PackLightmapAtlas()
+{
 	std::vector<LevelMeshSurface*> sortedSurfaces;
 	sortedSurfaces.reserve(Surfaces.Size());
 
 	for (auto& surface : Surfaces)
 	{
-		BuildSurfaceParams(LMTextureSize, LMTextureSize, surface);
 		sortedSurfaces.push_back(&surface);
 	}
-
-	BuildSmoothingGroups();
 
 	std::sort(sortedSurfaces.begin(), sortedSurfaces.end(), [](LevelMeshSurface* a, LevelMeshSurface* b) { return a->texHeight != b->texHeight ? a->texHeight > b->texHeight : a->texWidth > b->texWidth; });
 

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -30,6 +30,7 @@ public:
 	void CreatePortals();
 	void DumpMesh(const FString& objFilename, const FString& mtlFilename) const;
 	void BindLightmapSurfacesToGeometry(FLevelLocals& doomMap);
+	void PackLightmapAtlas();
 
 	bool TraceSky(const FVector3& start, FVector3 direction, float dist)
 	{

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -214,7 +214,7 @@ struct HWDrawInfo
 		{
 			surface->needsUpdate = true;
 		}
-		else if (VisibleSurfaces.Size() >= lm_max_updates)
+		else if (VisibleSurfaces.Size() >= unsigned(lm_max_updates))
 		{
 			return;
 		}


### PR DESCRIPTION
The optimization replaces linear search with TMap.

The fix for the mismatch in surface size is "use whatever surface size ZDRay came up with" and pack the lightmap atlas after the surfaces are modified.
