### PR TITLE
Raytrace alpha and color blending

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_levelmesh.h
+++ b/src/common/rendering/hwrenderer/data/hw_levelmesh.h
@@ -66,6 +66,7 @@ struct LevelMeshSurface
 	//
 
 	FTextureID texture = FNullTextureID();
+	float alpha = 1.0;
 	
 	int portalIndex = 0;
 	int sectorGroup = 0;

--- a/src/common/rendering/hwrenderer/data/hw_levelmesh.h
+++ b/src/common/rendering/hwrenderer/data/hw_levelmesh.h
@@ -8,8 +8,10 @@
 #include "common/utility/matrix.h"
 #include <memory>
 #include <cstring>
+#include "textureid.h"
 
 #include <dp_rect_pack.h>
+
 
 typedef dp::rect_pack::RectPacker<int> RectPacker;
 
@@ -62,6 +64,8 @@ struct LevelMeshSurface
 	//
 	// Required for internal lightmapper:
 	//
+
+	FTextureID texture = FNullTextureID();
 	
 	int portalIndex = 0;
 	int sectorGroup = 0;
@@ -193,6 +197,7 @@ public:
 	virtual ~LevelMesh() = default;
 
 	TArray<FVector3> MeshVertices;
+	TArray<FVector2> MeshVertexUVs;
 	TArray<int> MeshUVIndex;
 	TArray<uint32_t> MeshElements;
 	TArray<int> MeshSurfaceIndexes;

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -486,6 +486,7 @@ void VkLightmap::CreateRaytracePipeline()
 		raytrace.descriptorSetLayout1 = DescriptorSetLayoutBuilder()
 			.AddBinding(0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_FRAGMENT_BIT)
 			.AddBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT)
+			.AddBinding(2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT)
 			.DebugName("raytrace.descriptorSetLayout1")
 			.Create(fb->GetDevice());
 	}
@@ -579,6 +580,7 @@ void VkLightmap::UpdateAccelStructDescriptors()
 		WriteDescriptors()
 			.AddAccelerationStructure(raytrace.descriptorSet1.get(), 0, fb->GetRaytrace()->GetAccelStruct())
 			.AddBuffer(raytrace.descriptorSet1.get(), 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, fb->GetRaytrace()->GetVertexBuffer())
+			.AddBuffer(raytrace.descriptorSet1.get(), 2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, fb->GetRaytrace()->GetIndexBuffer())
 			.Execute(fb->GetDevice());
 	}
 	else

--- a/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_lightmap.cpp
@@ -412,6 +412,7 @@ void VkLightmap::CreateShaders()
 {
 	std::string prefix = "#version 460\r\n";
 	std::string traceprefix = "#version 460\r\n";
+	traceprefix += "#extension GL_EXT_nonuniform_qualifier : enable\r\n";
 	if (useRayQuery)
 	{
 		traceprefix += "#extension GL_EXT_ray_query : require\r\n";
@@ -484,6 +485,7 @@ void VkLightmap::CreateRaytracePipeline()
 	{
 		raytrace.descriptorSetLayout1 = DescriptorSetLayoutBuilder()
 			.AddBinding(0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_FRAGMENT_BIT)
+			.AddBinding(1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT)
 			.DebugName("raytrace.descriptorSetLayout1")
 			.Create(fb->GetDevice());
 	}
@@ -528,7 +530,7 @@ void VkLightmap::CreateRaytracePipeline()
 		.RenderPass(raytrace.renderPass.get())
 		.AddVertexShader(shaders.vertRaytrace.get())
 		.AddFragmentShader(shaders.fragRaytrace.get())
-		.AddVertexBufferBinding(0, sizeof(FVector4))
+		.AddVertexBufferBinding(0, sizeof(SurfaceVertex))
 		.AddVertexAttribute(0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0)
 		.Topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST)
 		.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT)
@@ -549,6 +551,7 @@ void VkLightmap::CreateRaytracePipeline()
 	{
 		raytrace.descriptorPool1 = DescriptorPoolBuilder()
 			.AddPoolSize(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1)
+			.AddPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1)
 			.MaxSets(1)
 			.DebugName("raytrace.descriptorPool1")
 			.Create(fb->GetDevice());
@@ -575,6 +578,7 @@ void VkLightmap::UpdateAccelStructDescriptors()
 	{
 		WriteDescriptors()
 			.AddAccelerationStructure(raytrace.descriptorSet1.get(), 0, fb->GetRaytrace()->GetAccelStruct())
+			.AddBuffer(raytrace.descriptorSet1.get(), 1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, fb->GetRaytrace()->GetVertexBuffer())
 			.Execute(fb->GetDevice());
 	}
 	else

--- a/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
@@ -103,7 +103,6 @@ void VkRaytrace::CreateBuffers()
 	std::vector<SurfaceVertex> vertices;
 	vertices.reserve(Mesh->MeshVertices.Size());
 	for (int i = 0, count = Mesh->MeshVertices.Size(); i < count; ++i)
-		//vertices.push_back({ { Mesh->MeshVertices[i], 1.0f } });
 		vertices.push_back({ { Mesh->MeshVertices[i], 1.0f }, Mesh->MeshVertexUVs[i], float(i), i + 10000.0f});
 
 	CollisionNodeBufferHeader nodesHeader;
@@ -132,6 +131,10 @@ void VkRaytrace::CreateBuffers()
 		{
 			auto mat = FMaterial::ValidateTexture(TexMan.GetGameTexture(surface->texture), 0);
 			info.TextureIndex = fb->GetBindlessTextureIndex(mat, CLAMP_NONE, 0);
+		}
+		else
+		{
+			info.TextureIndex = -1;
 		}
 
 		surfaceInfo.Push(info);
@@ -197,11 +200,6 @@ void VkRaytrace::CreateBuffers()
 	PipelineBarrier()
 		.AddMemory(VK_ACCESS_TRANSFER_WRITE_BIT, useRayQuery ? VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR : VK_ACCESS_SHADER_READ_BIT)
 		.Execute(fb->GetCommands()->GetTransferCommands(), VK_PIPELINE_STAGE_TRANSFER_BIT, useRayQuery ? VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
-
-	/*if (useRayQuery)
-		PipelineBarrier()
-			.AddMemory(VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT)
-			.Execute(fb->GetCommands()->GetTransferCommands(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);*/
 }
 
 void VkRaytrace::CreateBottomLevelAccelerationStructure()

--- a/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
@@ -137,6 +137,8 @@ void VkRaytrace::CreateBuffers()
 			info.TextureIndex = -1;
 		}
 
+		info.Alpha = surface->alpha;
+
 		surfaceInfo.Push(info);
 	}
 

--- a/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
+++ b/src/common/rendering/vulkan/accelstructs/vk_raytrace.cpp
@@ -193,15 +193,15 @@ void VkRaytrace::CreateBuffers()
 		.AddBuffer(surfaceBuffer.get(), surfaceInfo.Data(), surfaceInfo.Size() * sizeof(SurfaceInfo))
 		.AddBuffer(portalBuffer.get(), portalInfo.Data(), portalInfo.Size() * sizeof(PortalInfo))
 		.Execute(fb->GetDevice(), fb->GetCommands()->GetTransferCommands());
-	
+
 	PipelineBarrier()
 		.AddMemory(VK_ACCESS_TRANSFER_WRITE_BIT, useRayQuery ? VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR : VK_ACCESS_SHADER_READ_BIT)
 		.Execute(fb->GetCommands()->GetTransferCommands(), VK_PIPELINE_STAGE_TRANSFER_BIT, useRayQuery ? VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
 
-	if(useRayQuery)
+	/*if (useRayQuery)
 		PipelineBarrier()
 			.AddMemory(VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT)
-			.Execute(fb->GetCommands()->GetTransferCommands(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+			.Execute(fb->GetCommands()->GetTransferCommands(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);*/
 }
 
 void VkRaytrace::CreateBottomLevelAccelerationStructure()

--- a/src/common/rendering/vulkan/accelstructs/vk_raytrace.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_raytrace.h
@@ -34,7 +34,7 @@ struct SurfaceInfo
 	float SamplingDistance;
 	uint32_t PortalIndex;
 	int32_t TextureIndex;
-	float Padding;
+	float Alpha;
 };
 
 struct SurfaceVertex

--- a/src/common/rendering/vulkan/accelstructs/vk_raytrace.h
+++ b/src/common/rendering/vulkan/accelstructs/vk_raytrace.h
@@ -33,6 +33,14 @@ struct SurfaceInfo
 	float Sky;
 	float SamplingDistance;
 	uint32_t PortalIndex;
+	int32_t TextureIndex;
+	float Padding;
+};
+
+struct SurfaceVertex
+{
+	FVector4 pos;
+	FVector2 uv;
 	float Padding1, Padding2;
 };
 

--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1016,6 +1016,11 @@ public:
 		return pos == floor? floorplane:ceilingplane;
 	}
 
+	const secplane_t& GetSecPlane(int pos) const
+	{
+		return pos == floor ? floorplane : ceilingplane;
+	}
+
 	bool isSecret() const
 	{
 		return !!(Flags & SECF_SECRET);

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -1512,16 +1512,17 @@ void DoomLevelMesh::CreateSurfaceTextureUVs(FLevelLocals& doomMap)
 
 			if (surface.Type == ST_FLOOR || surface.Type == ST_CEILING)
 			{
+				for (int i = 0; i < surface.numVerts; ++i)
+				{
+					uvs[surface.atlasPageIndex + 0] = verts[0].XY() * (1.0f / 64.0f);
+				}
 			}
 			else
 			{
-				for (int i = 0; i < 4; ++i)
-				{
-					uvs[surface.atlasPageIndex + i] = verts[i] - verts[0];
-
-					uvs[surface.atlasPageIndex + i].X /= gtxt->GetDisplayWidth();
-					uvs[surface.atlasPageIndex + i].Y /= gtxt->GetDisplayHeight();
-				}
+				uvs[surface.atlasPageIndex + 0] = FVector2(0, 1); //toUv(&surface, verts[0] - verts[0]);
+				uvs[surface.atlasPageIndex + 1] = FVector2(1, 1); //toUv(&surface, verts[0] - verts[0]);
+				uvs[surface.atlasPageIndex + 2] = FVector2(0, 0); //toUv(&surface, verts[0] - verts[0]);
+				uvs[surface.atlasPageIndex + 3] = FVector2(1, 0); //toUv(&surface, verts[0] - verts[0]);
 			}
 		}
 	}

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -845,6 +845,7 @@ void DoomLevelMesh::CreateSideSurfaces(FLevelLocals &doomMap, side_t *side)
 		surf.ControlSector = nullptr;
 		surf.sectorGroup = sectorGroup[front->Index()];
 		surf.texture = texture;
+		surf.alpha = float(side->linedef->alpha);
 
 		Surfaces.Push(surf);
 	}

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -799,8 +799,8 @@ void DoomLevelMesh::CreateSideSurfaces(FLevelLocals &doomMap, side_t *side)
 
 			auto gameTexture = TexMan.GetGameTexture(texture);
 
-			float mid1Top = gameTexture->GetDisplayHeight();
-			float mid2Top = gameTexture->GetDisplayHeight();
+			float mid1Top = gameTexture->GetDisplayHeight() / side->textures[side_t::mid].yScale;
+			float mid2Top = gameTexture->GetDisplayHeight() / side->textures[side_t::mid].yScale;
 			float mid1Bottom = 0;
 			float mid2Bottom = 0;
 
@@ -812,7 +812,7 @@ void DoomLevelMesh::CreateSideSurfaces(FLevelLocals &doomMap, side_t *side)
 			}
 			else
 			{
-				yTextureOffset += side->sector->planes[sector_t::ceiling].TexZ - gameTexture->GetDisplayHeight();
+				yTextureOffset += side->sector->planes[sector_t::ceiling].TexZ - gameTexture->GetDisplayHeight() / side->textures[side_t::mid].yScale;
 			}
 
 			verts[0].Z = min(max(yTextureOffset + mid1Bottom, v1Bottom), v1Top);

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -66,10 +66,12 @@ private:
 	void CreateFloorSurface(FLevelLocals& doomMap, subsector_t* sub, sector_t* sector, sector_t* controlSector, int typeIndex);
 	void CreateSideSurfaces(FLevelLocals &doomMap, side_t *side);
 
+	void CreateSurfaceTextureUVs(FLevelLocals& doomMap);
+
 	void SetSubsectorLightmap(DoomLevelMeshSurface* surface);
 	void SetSideLightmap(DoomLevelMeshSurface* surface);
 
-	void SetupLightmapUvs();
+	void SetupLightmapUvs(FLevelLocals& doomMap);
 	void PropagateLight(const LevelMeshLight* light, std::set<LevelMeshPortal, RecursivePortalComparator>& touchedPortals, int lightPropagationRecursiveDepth);
 	void CreateLightList();
 

--- a/src/rendering/hwrenderer/scene/hw_drawstructs.h
+++ b/src/rendering/hwrenderer/scene/hw_drawstructs.h
@@ -79,7 +79,7 @@ struct HWSectorPlane
 	FVector2 Offs;
 	FVector2 Scale;
 
-	void GetFromSector(sector_t * sec, int ceiling)
+	void GetFromSector(const sector_t * sec, int ceiling)
 	{
 		Offs.X = (float)sec->GetXOffset(ceiling);
 		Offs.Y = (float)sec->GetYOffset(ceiling);

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -57,6 +57,41 @@ CVAR(Int, gl_breaksec, -1, 0)
 //
 //==========================================================================
 
+VSMatrix GetPlaneTextureRotationMatrix(FGameTexture* gltexture, const FVector2& uvOffset, float angle, const FVector2& scale)
+{
+	float uoffs = uvOffset.X / gltexture->GetDisplayWidth();
+	float voffs = uvOffset.Y / gltexture->GetDisplayHeight();
+
+	float yscale1 = scale.Y;
+	if (gltexture->isHardwareCanvas())
+	{
+		yscale1 = 0 - yscale1;
+	}
+
+	float xscale2 = 64.f / gltexture->GetDisplayWidth();
+	float yscale2 = 64.f / gltexture->GetDisplayHeight();
+
+	VSMatrix mat;
+	mat.loadIdentity();
+	mat.scale(scale.X, yscale1, 1.0f);
+	mat.translate(uoffs, voffs, 0.0f);
+	mat.scale(xscale2, yscale2, 1.0f);
+	mat.rotate(angle, 0.0f, 0.0f, 1.0f);
+	return mat;
+}
+
+VSMatrix GetPlaneTextureRotationMatrix(FGameTexture* gltexture, const HWSectorPlane& secplane)
+{
+	return GetPlaneTextureRotationMatrix(gltexture, secplane.Offs, -secplane.Angle, secplane.Scale);
+}
+
+VSMatrix GetPlaneTextureRotationMatrix(FGameTexture* gltexture, const sector_t* sector, int plane)
+{
+	HWSectorPlane splane;
+	splane.GetFromSector(sector, plane);
+	return GetPlaneTextureRotationMatrix(gltexture, splane);
+}
+
 bool SetPlaneTextureRotation(FRenderState& state, HWSectorPlane* secplane, FGameTexture* gltexture)
 {
 	// only manipulate the texture matrix if needed.
@@ -66,27 +101,7 @@ bool SetPlaneTextureRotation(FRenderState& state, HWSectorPlane* secplane, FGame
 		gltexture->GetDisplayWidth() != 64 ||
 		gltexture->GetDisplayHeight() != 64)
 	{
-		float uoffs = secplane->Offs.X / gltexture->GetDisplayWidth();
-		float voffs = secplane->Offs.Y / gltexture->GetDisplayHeight();
-
-		float xscale1 = secplane->Scale.X;
-		float yscale1 = secplane->Scale.Y;
-		if (gltexture->isHardwareCanvas())
-		{
-			yscale1 = 0 - yscale1;
-		}
-		float angle = -secplane->Angle;
-
-		float xscale2 = 64.f / gltexture->GetDisplayWidth();
-		float yscale2 = 64.f / gltexture->GetDisplayHeight();
-
-		VSMatrix mat;
-		mat.loadIdentity();
-		mat.scale(xscale1, yscale1, 1.0f);
-		mat.translate(uoffs, voffs, 0.0f);
-		mat.scale(xscale2, yscale2, 1.0f);
-		mat.rotate(angle, 0.0f, 0.0f, 1.0f);
-		state.SetTextureMatrix(mat);
+		state.SetTextureMatrix(GetPlaneTextureRotationMatrix(gltexture, *secplane));
 		return true;
 	}
 	return false;

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -1219,7 +1219,7 @@ void HWWall::CheckTexturePosition(FTexCoordInfo *tci)
 }
 
 
-static void GetTexCoordInfo(FGameTexture *tex, FTexCoordInfo *tci, side_t *side, int texpos)
+void GetTexCoordInfo(FGameTexture *tex, FTexCoordInfo *tci, side_t *side, int texpos)
 {
 	tci->GetFromTexture(tex, (float)side->GetTextureXScale(texpos), (float)side->GetTextureYScale(texpos), !!(side->GetLevel()->flags3 & LEVEL3_FORCEWORLDPANNING));
 }

--- a/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
+++ b/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
@@ -524,6 +524,11 @@ int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out fl
 			int index = primitiveID * 3;
 			vec2 uv = vertices[elements[index + 0]].uv * primitiveWeights.x + vertices[elements[index + 1]].uv * primitiveWeights.y + vertices[elements[index + 2]].uv * primitiveWeights.z;
 
+			if (surface.TextureIndex < 0)
+			{
+				break;
+			}
+
 			if (texture(textures[surface.TextureIndex], uv).w > 0.9)
 			{
 				break;

--- a/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
+++ b/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
@@ -31,11 +31,7 @@ struct SurfaceVertex
 };
 
 layout(std430, set = 1, binding = 1) buffer VertexBuffer { SurfaceVertex vertices[]; };
-
-#if defined(USE_RAYQUERY)
-#else
 layout(std430, set = 1, binding = 2) buffer ElementBuffer { int elements[]; };
-#endif
 
 layout(set = 0, binding = 0) uniform Uniforms
 {
@@ -259,6 +255,8 @@ int TraceFirstHitTriangleNoPortal(vec3 origin, float tmin, vec3 dir, float tmax,
 
 		primitiveWeights.xy = rayQueryGetIntersectionBarycentricsEXT(rayQuery, true);
 		primitiveWeights.z = 1.0 - primitiveWeights.x - primitiveWeights.y;
+
+		primitiveWeights = vec3(primitiveWeights.z, primitiveWeights.x, primitiveWeights.y);
 
 		return rayQueryGetIntersectionPrimitiveIndexEXT(rayQuery, true);
 	}

--- a/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
+++ b/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
@@ -512,7 +512,7 @@ int TraceFirstHitTriangleNoPortal(vec3 origin, float tmin, vec3 dir, float tmax,
 vec4 alphaBlend(vec4 a, vec4 b)
 {
 	float na = a.w + b.w * (1.0 - a.w);
-	return vec4((a.xyz * a.w + b.xyz * b.w * (1.0 - a.w)) / na, na);
+	return vec4((a.xyz * a.w + b.xyz * b.w * (1.0 - a.w)) / na, max(0.001, na));
 }
 
 vec4 blend(vec4 a, vec4 b)
@@ -536,6 +536,7 @@ int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out fl
 
 		if(surface.PortalIndex == 0)
 		{
+#if defined(USE_RAYQUERY)
 			int index = primitiveID * 3;
 			vec2 uv = vertices[elements[index + 0]].uv * primitiveWeights.x + vertices[elements[index + 1]].uv * primitiveWeights.y + vertices[elements[index + 2]].uv * primitiveWeights.z;
 
@@ -553,6 +554,9 @@ int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out fl
 			}
 
 			rayColor = blend(color, rayColor) * (1.0 - color.w);
+#else
+			break;
+#endif
 		}
 
 		// Portal was hit: Apply transformation onto the ray
@@ -598,6 +602,7 @@ bool TracePoint(vec3 origin, vec3 target, float tmin, vec3 dir, float tmax)
 
 		if (surface.PortalIndex == 0)
 		{
+#if defined(USE_RAYQUERY)
 			int index = primitiveID * 3;
 			vec2 uv = vertices[elements[index + 0]].uv * primitiveWeights.x + vertices[elements[index + 1]].uv * primitiveWeights.y + vertices[elements[index + 2]].uv * primitiveWeights.z;
 
@@ -615,6 +620,10 @@ bool TracePoint(vec3 origin, vec3 target, float tmin, vec3 dir, float tmax)
 			}
 
 			rayColor = blend(color, rayColor) * (1.0 - color.w);
+#else
+			rayColor.w = 0; // I suspect some rays are escaping out of bounds
+			break;
+#endif
 		}
 
 		if(dot(surface.Normal, dir) >= 0.0)

--- a/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
+++ b/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
@@ -521,7 +521,13 @@ int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out fl
 
 		if(surface.PortalIndex == 0)
 		{
-			break;
+			int index = primitiveID * 3;
+			vec2 uv = vertices[elements[index + 0]].uv * primitiveWeights.x + vertices[elements[index + 1]].uv * primitiveWeights.y + vertices[elements[index + 2]].uv * primitiveWeights.z;
+
+			if (texture(textures[surface.TextureIndex], uv).w > 0.9)
+			{
+				break;
+			}
 		}
 
 		// Portal was hit: Apply transformation onto the ray


### PR DESCRIPTION
The levelmesh wall surfaces are usually misaligned with HWWall.
Floors and ceilings should be accurate.
I didn't try 3D floors, I assume they just don't work correctly without crashing.

There are still many quirks and bugs to fix (front+back surfaces of the textures are stuck together which is responsible for random visual artefacts)

Note that the light blending is very WIP and the formula will change.
![image](https://github.com/dpjudas/VkDoom/assets/29225776/2a7c4bd2-5a6c-46cf-af35-e77177e13745)
![image](https://github.com/dpjudas/VkDoom/assets/29225776/4ce19721-2462-4e48-a86a-d4a16fa7623f)
