### PR TITLE
Better mid-texture color blending

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -1332,6 +1332,10 @@ void HWWall::DoMidTexture(HWDrawInfo *di, FRenderState& state, seg_t * seg, bool
 		if (auto lightmapPtr = seg->sidedef->lightmap)
 		{
 			lightmap = lightmapPtr[side_t::mid];
+			if (lightmap)
+			{
+				di->PushVisibleSurface(lightmap);
+			}
 		}
 
 		// Align the texture to the ORIGINAL sector's height!!

--- a/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
+++ b/wadsrc/static/shaders/lightmap/frag_raytrace.glsl
@@ -515,9 +515,16 @@ vec4 alphaBlend(vec4 a, vec4 b)
 	return vec4((a.xyz * a.w + b.xyz * b.w * (1.0 - a.w)) / na, max(0.001, na));
 }
 
+vec4 BeerLambertSimple(vec4 medium, vec4 ray_color) // based on Beer-Lambert law
+{
+	float z = medium.w;
+	ray_color.rgb *= exp(-medium.rgb * vec3(z));
+	return ray_color;
+}
+
 vec4 blend(vec4 a, vec4 b)
 {
-	return alphaBlend(a, b);
+	return BeerLambertSimple(vec4(1.0 - a.rgb, a.w), b);
 }
 
 int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out float t)
@@ -553,7 +560,7 @@ int TraceFirstHitTriangleT(vec3 origin, float tmin, vec3 dir, float tmax, out fl
 				break;
 			}
 
-			rayColor = blend(color, rayColor) * (1.0 - color.w);
+			rayColor = blend(color, rayColor);
 #else
 			break;
 #endif
@@ -619,7 +626,7 @@ bool TracePoint(vec3 origin, vec3 target, float tmin, vec3 dir, float tmax)
 				break;
 			}
 
-			rayColor = blend(color, rayColor) * (1.0 - color.w);
+			rayColor = blend(color, rayColor);
 #else
 			rayColor.w = 0; // I suspect some rays are escaping out of bounds
 			break;


### PR DESCRIPTION
uses a simplified Beer–Lambert law... not sure if correctly, but it looks nicer.

(blue, red+green light, white light)
Here's the **old version**:
![image](https://github.com/dpjudas/VkDoom/assets/29225776/cfea8e06-fe86-4038-b56f-b9b498d74e67)
![image](https://github.com/dpjudas/VkDoom/assets/29225776/9c857763-ee1b-48ef-8326-f0933c25e41a)

Now the surface absorbs the colored light:

![image](https://github.com/dpjudas/VkDoom/assets/29225776/eb293628-dac8-4c33-9b30-d76c31ec8c2b)
![image](https://github.com/dpjudas/VkDoom/assets/29225776/312d8537-65b7-4e4e-b471-3e76b9a6fb5b)
