### PR TITLE
Attempt to fix compilation errors on other platforms

### DIFF
--- a/src/common/rendering/vulkan/vk_levelmesh.cpp
+++ b/src/common/rendering/vulkan/vk_levelmesh.cpp
@@ -28,7 +28,7 @@
 #include "hw_material.h"
 #include "texturemanager.h"
 
-bool vk_rayquery = true;
+extern bool vk_rayquery;
 
 VkLevelMesh::VkLevelMesh(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/vk_levelmesh.cpp
+++ b/src/common/rendering/vulkan/vk_levelmesh.cpp
@@ -28,7 +28,7 @@
 #include "hw_material.h"
 #include "texturemanager.h"
 
-extern bool vk_rayquery;
+EXTERN_CVAR(Bool, vk_rayquery);
 
 VkLevelMesh::VkLevelMesh(VulkanRenderDevice* fb) : fb(fb)
 {


### PR DESCRIPTION
The compilation failed because there was more than one vk_rayquery variable (A CVAR and a hard-coded global true value), so I removed the latter.