### PR TITLE
Fix redundant 2D shadowmap test for lightmap lights

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -158,7 +158,7 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FLig
 			dist = (float)L.LengthSquared();
 			radius = light->GetRadius();
 
-			if (dist < radius * radius)
+			if (radius > 0 && dist < radius * radius)
 			{
 				dist = sqrtf(dist);	// only calculate the square root if we really need it.
 
@@ -181,7 +181,7 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FLig
 						frac *= (float)smoothstep(light->pSpotOuterAngle->Cos(), light->pSpotInnerAngle->Cos(), cosDir);
 					}
 
-					if (frac > 0 && (!light->shadowmapped || (light->GetRadius() > 0 && screen->mShadowMap->ShadowTest(light->Pos, { x, y, z }))))
+					if (frac > 0 && (!light->shadowmapped || light->Trace() || screen->mShadowMap->ShadowTest(light->Pos, { x, y, z })))
 					{
 						lr = light->GetRed() / 255.0f;
 						lg = light->GetGreen() / 255.0f;


### PR DESCRIPTION
When applying tracelights onto actors, both 3D levelmesh and 2D shadowmap are tested.

To my knowledge checking 2D shadowmap is basically redundant and causes extreme slowdowns when many sprites are tested against many tracelights.
Before (30 FPS max):
![Screenshot_Doom_20240619_122010](https://github.com/dpjudas/VkDoom/assets/29225776/7df85aa1-55b7-4b82-8b17-c4b8c77dc438)

After (196 FPS max):
![Screenshot_Doom_20240619_122250](https://github.com/dpjudas/VkDoom/assets/29225776/edf83231-3b44-4ae8-b543-8d562954f1ea)

