### PR TITLE
Fix: Apply 2D shadowmapping to particles

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -181,7 +181,7 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FLig
 						frac *= (float)smoothstep(light->pSpotOuterAngle->Cos(), light->pSpotInnerAngle->Cos(), cosDir);
 					}
 
-					if (frac > 0 && (!light->shadowmapped || light->Trace() || screen->mShadowMap->ShadowTest(light->Pos, { x, y, z })))
+					if (frac > 0 && (!light->shadowmapped || (self && light->Trace()) || screen->mShadowMap->ShadowTest(light->Pos, { x, y, z })))
 					{
 						lr = light->GetRed() / 255.0f;
 						lg = light->GetGreen() / 255.0f;


### PR DESCRIPTION
Turns out particles do not use levelmesh but 2D shadowmapping only for tracelights. This restores that behavior.