### PR TITLE
remove transitive includes using the include-what-you-use tool

### DIFF
--- a/src/common/filesystem/include/fs_findfile.h
+++ b/src/common/filesystem/include/fs_findfile.h
@@ -2,6 +2,7 @@
 // Directory searching routines
 
 #include <stdint.h>
+#include <stddef.h>
 #include <vector>
 #include <string>
 
@@ -22,6 +23,7 @@ struct FileListEntry
 using FileList = std::vector<FileListEntry>;
 
 struct FCompressedBuffer;
+
 bool ScanDirectory(std::vector<FileListEntry>& list, const char* dirpath, const char* match, bool nosubdir = false, bool readhidden = false);
 bool FS_DirEntryExists(const char* pathname, bool* isdir);
 

--- a/src/common/filesystem/source/ancientzip.cpp
+++ b/src/common/filesystem/source/ancientzip.cpp
@@ -45,8 +45,11 @@
 
 #include <stdlib.h>
 #include <assert.h>
+#include <string.h>
 #include <memory>
+
 #include "ancientzip.h"
+#include "fs_files.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/ancientzip.h
+++ b/src/common/filesystem/source/ancientzip.h
@@ -1,7 +1,10 @@
 #pragma once
+#include <vector>
+
 #include "fs_files.h"
 
 namespace FileSys {
+class FileReader;
 	
 class FZipExploder
 {

--- a/src/common/filesystem/source/file_7z.cpp
+++ b/src/common/filesystem/source/file_7z.cpp
@@ -33,17 +33,26 @@
 **
 */
 
+#include <7zTypes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <mutex>
+#include <string>
+#include <vector>
+
 // Note that 7z made the unwise decision to include windows.h :(
 #include "7z.h"
 #include "7zCrc.h"
 #include "resourcefile.h"
-#include "fs_findfile.h"
 #include "unicode.h"
 #include "critsec.h"
-#include <mutex>
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 
 namespace FileSys {
+class StringPool;
 	
 //-----------------------------------------------------------------------
 //

--- a/src/common/filesystem/source/file_directory.cpp
+++ b/src/common/filesystem/source/file_directory.cpp
@@ -34,11 +34,19 @@
 */
 
 
-#include <sys/stat.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <functional>
+#include <string>
+#include <vector>
 
 #include "resourcefile.h"
 #include "fs_findfile.h"
 #include "fs_stringpool.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/file_grp.cpp
+++ b/src/common/filesystem/source/file_grp.cpp
@@ -33,10 +33,17 @@
 **
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "resourcefile.h"
 #include "fs_swap.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
 	using namespace byteswap;
 
 //==========================================================================

--- a/src/common/filesystem/source/file_hog.cpp
+++ b/src/common/filesystem/source/file_hog.cpp
@@ -35,10 +35,18 @@
 */
 
 
+#include <stdint.h>
+#include <string.h>
+#include <vector>
+
 #include "resourcefile.h"
 #include "fs_swap.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
     using namespace byteswap;
 
 

--- a/src/common/filesystem/source/file_lump.cpp
+++ b/src/common/filesystem/source/file_lump.cpp
@@ -32,9 +32,15 @@
 **
 */
 
+#include <stddef.h>
+#include <string>
+
 #include "resourcefile.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
 //==========================================================================
 //
 // Open it

--- a/src/common/filesystem/source/file_mvl.cpp
+++ b/src/common/filesystem/source/file_mvl.cpp
@@ -35,10 +35,16 @@
 */
 
 
+#include <stdint.h>
+#include <string.h>
+
 #include "resourcefile.h"
 #include "fs_swap.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
     using namespace byteswap;
 
 

--- a/src/common/filesystem/source/file_pak.cpp
+++ b/src/common/filesystem/source/file_pak.cpp
@@ -32,9 +32,16 @@
 **
 */
 
+#include <stdint.h>
+#include <string.h>
+
 #include "resourcefile.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
+#include "fs_swap.h"
 
 namespace FileSys {
+class StringPool;
 
 	using namespace byteswap;
 //==========================================================================

--- a/src/common/filesystem/source/file_rff.cpp
+++ b/src/common/filesystem/source/file_rff.cpp
@@ -34,10 +34,17 @@
 */
 
 #include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
 #include "resourcefile.h"
 #include "fs_swap.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
 	using namespace byteswap;
 
 //==========================================================================

--- a/src/common/filesystem/source/file_ssi.cpp
+++ b/src/common/filesystem/source/file_ssi.cpp
@@ -33,9 +33,16 @@
 **
 */
 
+#include <stdint.h>
+#include <string.h>
+#include <utility>
+
 #include "resourcefile.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
 
 //==========================================================================
 //

--- a/src/common/filesystem/source/file_wad.cpp
+++ b/src/common/filesystem/source/file_wad.cpp
@@ -34,11 +34,15 @@
 */
 
 #include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#include <vector>
+
 #include "resourcefile.h"
-#include "fs_filesystem.h"
 #include "fs_swap.h"
 #include "fs_stringpool.h"
-#include "resourcefile.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
 	using namespace byteswap;

--- a/src/common/filesystem/source/file_whres.cpp
+++ b/src/common/filesystem/source/file_whres.cpp
@@ -34,11 +34,18 @@
 **
 */
 
+#include <stdint.h>
+#include <stdio.h>
+#include <string>
+
 #include "resourcefile.h"
-#include "fs_stringpool.h"
 #include "fs_swap.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
 	using namespace byteswap;
 
 //==========================================================================

--- a/src/common/filesystem/source/file_zip.cpp
+++ b/src/common/filesystem/source/file_zip.cpp
@@ -34,16 +34,22 @@
 */
 
 #include <time.h>
-#include <stdexcept>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 #include <cstdint>
+#include <algorithm>
+#include <string>
+
 #include "w_zip.h"
-#include "ancientzip.h"
 #include "resourcefile.h"
-#include "fs_findfile.h"
 #include "fs_swap.h"
-#include "fs_stringpool.h"
+#include "fs_decompress.h"
+#include "fs_files.h"
 
 namespace FileSys {
+class StringPool;
+
 	using namespace byteswap;
 
 #define BUFREADCOMMENT (0x400)

--- a/src/common/filesystem/source/files.cpp
+++ b/src/common/filesystem/source/files.cpp
@@ -33,12 +33,17 @@
 **
 */
 
+#include <assert.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdio.h>
 #include <string>
 #include <memory>
 #include <algorithm>
-#include <assert.h>
-#include <string.h>
+#include <vector>
+
 #include "files_internal.h"
+#include "fs_files.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/files_decompress.cpp
+++ b/src/common/filesystem/source/files_decompress.cpp
@@ -35,19 +35,28 @@
 
 // Caution: LzmaDec also pulls in windows.h!
 #define NOMINMAX
+#include <miniz.h>
+#include <bzlib.h>
+#include <7zTypes.h>
+#include <assert.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <algorithm>
+#include <exception>
+#include <utility>
+
 #include "LzmaDec.h"
 #include "Xz.h"
 // CRC table needs to be generated prior to reading XZ compressed files.
 #include "7zCrc.h"
-#include <miniz.h>
-#include <bzlib.h>
-#include <algorithm>
-#include <stdexcept>
-
 #include "fs_files.h"
 #include "files_internal.h"
 #include "ancientzip.h"
 #include "fs_decompress.h"
+#include "fs_swap.h"
 
 namespace FileSys {
 	using namespace byteswap;
@@ -251,6 +260,7 @@ public:
 //==========================================================================
 
 class DecompressorBZ2;
+
 static DecompressorBZ2 * stupidGlobal;	// Why does that dumb global error callback not pass the decompressor state?
 										// Thanks to that brain-dead interface we have to use a global variable to get the error to the proper handler.
 

--- a/src/common/filesystem/source/filesystem.cpp
+++ b/src/common/filesystem/source/filesystem.cpp
@@ -36,17 +36,25 @@
 
 // HEADER FILES ------------------------------------------------------------
 
-#include <miniz.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
 #include <inttypes.h>
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "resourcefile.h"
 #include "fs_filesystem.h"
 #include "fs_findfile.h"
 #include "md5.hpp"
 #include "fs_stringpool.h"
+#include "fs_files.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/fs_findfile.cpp
+++ b/src/common/filesystem/source/fs_findfile.cpp
@@ -33,6 +33,7 @@
 */
 
 #include "fs_findfile.h"
+
 #include <string.h>
 #include <vector>
 
@@ -43,10 +44,8 @@
 #ifdef __FreeBSD__
 #include <sys/time.h>
 #endif
-#include <unistd.h>
 #include <fnmatch.h>
 #include <sys/stat.h>
-
 #include <dirent.h>
 
 #else

--- a/src/common/filesystem/source/fs_stringpool.h
+++ b/src/common/filesystem/source/fs_stringpool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+
 namespace FileSys {
 // Storage for all the static strings the file system must hold.
 class StringPool

--- a/src/common/filesystem/source/resourcefile.cpp
+++ b/src/common/filesystem/source/resourcefile.cpp
@@ -35,15 +35,25 @@
 */
 
 #include <miniz.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "resourcefile.h"
 #include "md5.hpp"
 #include "fs_stringpool.h"
-#include "files_internal.h"
 #include "unicode.h"
 #include "fs_findfile.h"
 #include "fs_decompress.h"
 #include "wildcards.hpp"
-#include <algorithm>
+#include "fs_files.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/unicode.cpp
+++ b/src/common/filesystem/source/unicode.cpp
@@ -33,6 +33,9 @@
 */
 
 #include "unicode.h"
+
+#include <stdint.h>
+
 #include "utf8proc.h"
 
 namespace FileSys {

--- a/src/common/filesystem/source/unicode.h
+++ b/src/common/filesystem/source/unicode.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <vector>
+
 namespace FileSys {
 	
 void utf16_to_utf8(const unsigned short* in, std::vector<char>& buffer);

--- a/src/common/platform/posix/i_system_posix.cpp
+++ b/src/common/platform/posix/i_system_posix.cpp
@@ -28,14 +28,18 @@
 **---------------------------------------------------------------------------
 **
 */
-#include <fnmatch.h>
 
 #ifdef __APPLE__
 #include <AvailabilityMacros.h>
 #endif // __APPLE__
 
-#include "cmdlib.h"
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "i_system.h"
+#include "tarray.h"
+#include "zstring.h"
 
 
 bool I_WriteIniFailed(const char * filename)

--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -34,13 +34,15 @@
 */
 
 #include <sys/stat.h>
-#include <sys/types.h>
-#include "i_system.h"
-#include "cmdlib.h"
-#include "printf.h"
-#include "engineerrors.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "cmdlib.h"
+#include "engineerrors.h"
 #include "version.h"	// for GAMENAME
+#include "zstring.h"
 
 
 FString GetUserFile (const char *file)

--- a/src/common/rendering/vulkan/buffers/vk_buffer.cpp
+++ b/src/common/rendering/vulkan/buffers/vk_buffer.cpp
@@ -21,12 +21,16 @@
 */
 
 #include "vk_buffer.h"
+
+#include <stdint.h>
+#include <vector>
+
 #include "vk_hwbuffer.h"
 #include "vk_rsbuffers.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/pipelines/vk_renderpass.h"
-#include "vulkan/commands/vk_commandbuffer.h"
-#include <zvulkan/vulkanbuilders.h>
+#include "buffers.h"
+#include "tarray.h"
 
 VkBufferManager::VkBufferManager(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/buffers/vk_buffer.h
+++ b/src/common/rendering/vulkan/buffers/vk_buffer.h
@@ -1,8 +1,12 @@
 
 #pragma once
 
-#include "zvulkan/vulkanobjects.h"
+#include <stddef.h>
 #include <list>
+#include <memory>
+
+#include "zvulkan/vulkanobjects.h"
+#include "vulkan/buffers/vk_hwbuffer.h"
 
 class VulkanRenderDevice;
 class VkHardwareBuffer;

--- a/src/common/rendering/vulkan/buffers/vk_hwbuffer.cpp
+++ b/src/common/rendering/vulkan/buffers/vk_hwbuffer.cpp
@@ -21,13 +21,19 @@
 */
 
 #include "vk_hwbuffer.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <string.h>
+#include <algorithm>
+#include <utility>
+
 #include "vk_buffer.h"
 #include "vulkan/vk_renderdevice.h"
-#include "vulkan/vk_renderstate.h"
 #include "vulkan/commands/vk_commandbuffer.h"
-#include "vulkan/descriptorsets/vk_descriptorset.h"
-#include <zvulkan/vulkanbuilders.h>
-#include "engineerrors.h"
+#include "basics.h"
+#include "buffers.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkHardwareBuffer::VkHardwareBuffer(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/buffers/vk_hwbuffer.h
+++ b/src/common/rendering/vulkan/buffers/vk_hwbuffer.h
@@ -1,11 +1,17 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+#include <list>
+#include <memory>
+
 #include "hwrenderer/data/buffers.h"
 #include "zvulkan/vulkanobjects.h"
 #include "tarray.h"
-#include <list>
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
+class VulkanBuffer;
 
 class VkHardwareBuffer : public IBuffer
 {

--- a/src/common/rendering/vulkan/buffers/vk_rsbuffers.cpp
+++ b/src/common/rendering/vulkan/buffers/vk_rsbuffers.cpp
@@ -21,12 +21,23 @@
 */
 
 #include "vk_rsbuffers.h"
-#include "vulkan/vk_renderstate.h"
-#include "vulkan/vk_renderdevice.h"
-#include "vulkan/buffers/vk_buffer.h"
+
 #include <zvulkan/vulkanbuilders.h>
+#include <string.h>
+#include <vector>
+
+#include "vulkan/vk_renderdevice.h"
 #include "flatvertices.h"
 #include "cmdlib.h"
+#include "buffers.h"
+#include "hw_renderstate.h"
+#include "hw_surfaceuniforms.h"
+#include "hw_viewpointuniforms.h"
+#include "matrix.h"
+#include "vectors.h"
+#include "vulkan/pipelines/vk_renderpass.h"
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
 
 VkRSBuffers::VkRSBuffers(VulkanRenderDevice* fb)
 {

--- a/src/common/rendering/vulkan/buffers/vk_rsbuffers.h
+++ b/src/common/rendering/vulkan/buffers/vk_rsbuffers.h
@@ -1,12 +1,19 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+#include <memory>
+
 #include "vulkan/buffers/vk_hwbuffer.h"
 #include "vulkan/shaders/vk_shader.h"
+#include "zvulkan/vulkanobjects.h"
 
 class VkMatrixBufferWriter;
 class VkSurfaceUniformsBufferWriter;
 struct FFlatVertex;
+class VulkanRenderDevice;
+struct SurfaceUniforms;
 
 class VkRSBuffers
 {

--- a/src/common/rendering/vulkan/commands/vk_commandbuffer.cpp
+++ b/src/common/rendering/vulkan/commands/vk_commandbuffer.cpp
@@ -21,15 +21,22 @@
 */
 
 #include "vk_commandbuffer.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <algorithm>
+#include <limits>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_renderstate.h"
-#include "vulkan/vk_postprocess.h"
 #include "vulkan/framebuffers/vk_framebuffer.h"
 #include "vulkan/descriptorsets/vk_descriptorset.h"
-#include <zvulkan/vulkanswapchain.h>
-#include <zvulkan/vulkanbuilders.h>
 #include "hw_clock.h"
-#include "v_video.h"
+#include "basics.h"
+#include "stats.h"
+#include "zvulkan/volk/volk.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
+#include "zvulkan/vulkanobjects.h"
 
 extern int rendered_commandbuffers;
 int current_rendered_commandbuffers;

--- a/src/common/rendering/vulkan/commands/vk_commandbuffer.h
+++ b/src/common/rendering/vulkan/commands/vk_commandbuffer.h
@@ -2,7 +2,15 @@
 
 #include <zvulkan/vulkandevice.h>
 #include <zvulkan/vulkanobjects.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <memory>
+#include <mutex>
+#include <utility>
+#include <vector>
+
 #include "zstring.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
 

--- a/src/common/rendering/vulkan/descriptorsets/vk_descriptorset.cpp
+++ b/src/common/rendering/vulkan/descriptorsets/vk_descriptorset.cpp
@@ -21,11 +21,14 @@
 */
 
 #include "vk_descriptorset.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <utility>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_levelmesh.h"
 #include "vulkan/shaders/vk_shader.h"
 #include "vulkan/samplers/vk_samplers.h"
-#include "vulkan/textures/vk_renderbuffers.h"
 #include "vulkan/textures/vk_hwtexture.h"
 #include "vulkan/textures/vk_texture.h"
 #include "vulkan/buffers/vk_hwbuffer.h"
@@ -33,10 +36,11 @@
 #include "vulkan/buffers/vk_rsbuffers.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vulkan/pipelines/vk_pprenderpass.h"
-#include <zvulkan/vulkanbuilders.h>
-#include "flatvertices.h"
 #include "hw_viewpointuniforms.h"
-#include "v_2ddrawer.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "textures.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "vulkan/vulkan_core.h"
 
 VkDescriptorSetManager::VkDescriptorSetManager(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/descriptorsets/vk_descriptorset.h
+++ b/src/common/rendering/vulkan/descriptorsets/vk_descriptorset.h
@@ -1,9 +1,11 @@
 
 #pragma once
 
+#include <list>
+#include <memory>
+
 #include "zvulkan/vulkanobjects.h"
 #include "zvulkan/vulkanbuilders.h"
-#include <list>
 #include "tarray.h"
 
 class VulkanRenderDevice;

--- a/src/common/rendering/vulkan/framebuffers/vk_framebuffer.cpp
+++ b/src/common/rendering/vulkan/framebuffers/vk_framebuffer.cpp
@@ -21,12 +21,13 @@
 */
 
 #include <zvulkan/vulkanobjects.h>
-#include <zvulkan/vulkandevice.h>
 #include <zvulkan/vulkanbuilders.h>
 #include <zvulkan/vulkanswapchain.h>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_postprocess.h"
 #include "vk_framebuffer.h"
+#include "c_cvars.h"
 
 CVAR(Bool, vk_hdr, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR(Bool, vk_exclusivefullscreen, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);

--- a/src/common/rendering/vulkan/framebuffers/vk_framebuffer.h
+++ b/src/common/rendering/vulkan/framebuffers/vk_framebuffer.h
@@ -1,13 +1,16 @@
 
 #pragma once
 
-#include "zvulkan/vulkanobjects.h"
 #include <array>
 #include <map>
+#include <memory>
+
+#include "zvulkan/vulkanobjects.h"
 
 class VulkanRenderDevice;
 enum class PPFilterMode;
 enum class PPWrapMode;
+class VulkanSwapChain;
 
 class VkFramebufferManager
 {

--- a/src/common/rendering/vulkan/pipelines/vk_pprenderpass.cpp
+++ b/src/common/rendering/vulkan/pipelines/vk_pprenderpass.cpp
@@ -21,11 +21,13 @@
 */
 
 #include "vk_pprenderpass.h"
-#include "vulkan/vk_renderstate.h"
+
+#include <zvulkan/vulkanbuilders.h>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/shaders/vk_ppshader.h"
 #include "vulkan/textures/vk_renderbuffers.h"
-#include <zvulkan/vulkanbuilders.h>
+#include "vulkan/pipelines/vk_renderpass.h"
 
 VkPPRenderPassSetup::VkPPRenderPassSetup(VulkanRenderDevice* fb, const VkPPRenderPassKey& key) : fb(fb)
 {

--- a/src/common/rendering/vulkan/pipelines/vk_pprenderpass.h
+++ b/src/common/rendering/vulkan/pipelines/vk_pprenderpass.h
@@ -1,10 +1,13 @@
 
 #pragma once
 
-#include "zvulkan/vulkanobjects.h"
-#include "hwrenderer/postprocessing/hw_postprocess.h"
 #include <string.h>
 #include <map>
+#include <memory>
+
+#include "zvulkan/vulkanobjects.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
 class VkPPShader;

--- a/src/common/rendering/vulkan/pipelines/vk_renderpass.cpp
+++ b/src/common/rendering/vulkan/pipelines/vk_renderpass.cpp
@@ -21,21 +21,22 @@
 */
 
 #include "vk_renderpass.h"
+
+#include <zvulkan/vulkanbuilders.h>
+
 #include "vk_pprenderpass.h"
-#include "vulkan/vk_renderstate.h"
 #include "vulkan/vk_renderdevice.h"
-#include "vulkan/vk_levelmesh.h"
 #include "vulkan/descriptorsets/vk_descriptorset.h"
 #include "vulkan/textures/vk_renderbuffers.h"
-#include "vulkan/samplers/vk_samplers.h"
 #include "vulkan/shaders/vk_shader.h"
-#include "vulkan/buffers/vk_hwbuffer.h"
-#include <zvulkan/vulkanbuilders.h>
-#include "flatvertices.h"
-#include "hw_viewpointuniforms.h"
-#include "v_2ddrawer.h"
 #include "i_specialpaths.h"
 #include "cmdlib.h"
+#include "buffers.h"
+#include "files.h"
+#include "fs_files.h"
+#include "hw_renderstate.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
 
 VkRenderPassManager::VkRenderPassManager(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/pipelines/vk_renderpass.h
+++ b/src/common/rendering/vulkan/pipelines/vk_renderpass.h
@@ -1,14 +1,21 @@
 
 #pragma once
 
+#include <string.h>
+#include <stdint.h>
+#include <map>
+#include <memory>
+#include <vector>
+
 #include "zvulkan/vulkanobjects.h"
 #include "renderstyle.h"
 #include "hwrenderer/data/buffers.h"
 #include "hwrenderer/postprocessing/hw_postprocess.h"
 #include "hw_renderstate.h"
 #include "common/rendering/vulkan/shaders/vk_shader.h"
-#include <string.h>
-#include <map>
+#include "vulkan/pipelines/vk_pprenderpass.h"
+#include "vulkan/vulkan_core.h"
+#include "zstring.h"
 
 class VulkanRenderDevice;
 class ColorBlendAttachmentBuilder;

--- a/src/common/rendering/vulkan/samplers/vk_samplers.cpp
+++ b/src/common/rendering/vulkan/samplers/vk_samplers.cpp
@@ -23,16 +23,19 @@
 #include <zvulkan/vulkanobjects.h>
 #include <zvulkan/vulkandevice.h>
 #include <zvulkan/vulkanbuilders.h>
+#include <stdint.h>
+#include <unordered_set>
+#include <utility>
+
 #include "c_cvars.h"
-#include "v_video.h"
 #include "hw_cvars.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vk_samplers.h"
-#include "hw_material.h"
 #include "i_interface.h"
 #include "hwrenderer/postprocessing/hw_postprocess.h"
-#include <unordered_set>
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vulkaninstance.h"
 
 struct VkTexFilter
 {

--- a/src/common/rendering/vulkan/samplers/vk_samplers.h
+++ b/src/common/rendering/vulkan/samplers/vk_samplers.h
@@ -1,8 +1,12 @@
 
 #pragma once
 
-#include "zvulkan/vulkanobjects.h"
 #include <array>
+#include <memory>
+
+#include "zvulkan/vulkanobjects.h"
+#include "gametexture.h"
+#include "textures.h"
 
 class VulkanRenderDevice;
 enum class PPFilterMode;

--- a/src/common/rendering/vulkan/shaders/vk_ppshader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_ppshader.cpp
@@ -21,12 +21,23 @@
 */
 
 #include "vk_ppshader.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <functional>
+#include <string>
+#include <utility>
+
 #include "vk_shader.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/commands/vk_commandbuffer.h"
-#include <zvulkan/vulkanbuilders.h>
 #include "filesystem.h"
 #include "cmdlib.h"
+#include "engineerrors.h"
+#include "fs_filesystem.h"
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkPPShader::VkPPShader(VulkanRenderDevice* fb, PPShader *shader) : fb(fb)
 {

--- a/src/common/rendering/vulkan/shaders/vk_ppshader.h
+++ b/src/common/rendering/vulkan/shaders/vk_ppshader.h
@@ -1,12 +1,18 @@
 
 #pragma once
 
-#include "hwrenderer/postprocessing/hw_postprocess.h"
 #include <zvulkan/vulkanobjects.h>
+#include <stddef.h>
 #include <list>
+#include <memory>
+#include <vector>
+
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "zstring.h"
 
 class VulkanRenderDevice;
 class ShaderIncludeResult;
+class VulkanShader;
 
 class VkPPShader : public PPShaderBackend
 {

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -21,14 +21,26 @@
 */
 
 #include "vk_shader.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <stddef.h>
+#include <functional>
+#include <string>
+
 #include "vk_ppshader.h"
 #include "vulkan/vk_renderdevice.h"
-#include <zvulkan/vulkanbuilders.h>
 #include "hw_shaderpatcher.h"
 #include "filesystem.h"
 #include "engineerrors.h"
-#include "version.h"
 #include "cmdlib.h"
+#include "fs_filesystem.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "renderstyle.h"
+#include "tarray.h"
+#include "textures.h"
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
 
 VkShaderManager::VkShaderManager(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/shaders/vk_shader.h
+++ b/src/common/rendering/vulkan/shaders/vk_shader.h
@@ -1,14 +1,19 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <string.h>
 #include <memory>
+#include <list>
+#include <map>
 
 #include "vectors.h"
 #include "matrix.h"
 #include "name.h"
 #include "hw_renderstate.h"
-#include <list>
-#include <map>
+#include "hw_surfaceuniforms.h"
+#include "zstring.h"
+#include "zvulkan/vulkanobjects.h"
 
 class ShaderIncludeResult;
 class VulkanRenderDevice;

--- a/src/common/rendering/vulkan/textures/vk_hwtexture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_hwtexture.cpp
@@ -21,12 +21,14 @@
 */
 
 
-#include "c_cvars.h"
-#include "hw_material.h"
-#include "hw_cvars.h"
-#include "hw_renderstate.h"
 #include <zvulkan/vulkanobjects.h>
 #include <zvulkan/vulkanbuilders.h>
+#include <string.h>
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "hw_material.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_postprocess.h"
 #include "vulkan/commands/vk_commandbuffer.h"
@@ -34,8 +36,15 @@
 #include "vulkan/textures/vk_renderbuffers.h"
 #include "vulkan/textures/vk_texture.h"
 #include "vulkan/descriptorsets/vk_descriptorset.h"
-#include "vulkan/shaders/vk_shader.h"
 #include "vk_hwtexture.h"
+#include "basics.h"
+#include "gametexture.h"
+#include "hw_materialstate.h"
+#include "hw_texcontainer.h"
+#include "palettecontainer.h"
+#include "textures.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
 
 VkHardwareTexture::VkHardwareTexture(VulkanRenderDevice* fb, int numchannels) : fb(fb)
 {

--- a/src/common/rendering/vulkan/textures/vk_hwtexture.h
+++ b/src/common/rendering/vulkan/textures/vk_hwtexture.h
@@ -7,12 +7,16 @@
 #define SHADED_TEXTURE -1
 #define DIRECT_PALETTE -2
 
+#include <zvulkan/vulkanobjects.h>
+#include <stdint.h>
+#include <list>
+#include <vector>
+
 #include "tarray.h"
 #include "hw_ihwtexture.h"
-#include <zvulkan/vulkanobjects.h>
 #include "vk_imagetransition.h"
 #include "hw_material.h"
-#include <list>
+#include "vulkan/vulkan_core.h"
 
 struct FMaterialState;
 class VulkanDescriptorSet;
@@ -21,6 +25,7 @@ class VulkanImageView;
 class VulkanBuffer;
 class VulkanRenderDevice;
 class FGameTexture;
+class FTexture;
 
 class VkHardwareTexture : public IHardwareTexture
 {

--- a/src/common/rendering/vulkan/textures/vk_imagetransition.cpp
+++ b/src/common/rendering/vulkan/textures/vk_imagetransition.cpp
@@ -22,6 +22,11 @@
 
 #include "vk_imagetransition.h"
 
+#include <algorithm>
+
+#include "basics.h"
+#include "engineerrors.h"
+
 VkImageTransition& VkImageTransition::AddImage(VkTextureImage *image, VkImageLayout targetLayout, bool undefinedSrcLayout, int baseMipLevel, int levelCount, int baseArrayLayer, int layerCount)
 {
 	if (image->Layout == targetLayout)

--- a/src/common/rendering/vulkan/textures/vk_imagetransition.h
+++ b/src/common/rendering/vulkan/textures/vk_imagetransition.h
@@ -1,11 +1,17 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include "zvulkan/vulkanobjects.h"
 #include "zvulkan/vulkanbuilders.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vulkan/pipelines/vk_renderpass.h"
+#include "vulkan/vulkan_core.h"
 
 class VkTextureImage
 {

--- a/src/common/rendering/vulkan/textures/vk_pptexture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_pptexture.cpp
@@ -21,9 +21,17 @@
 */
 
 #include "vk_pptexture.h"
+
+#include <string.h>
+#include <utility>
+
 #include "vk_texture.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/commands/vk_commandbuffer.h"
+#include "engineerrors.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/vulkanbuilders.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkPPTexture::VkPPTexture(VulkanRenderDevice* fb, PPTexture *texture) : fb(fb)
 {

--- a/src/common/rendering/vulkan/textures/vk_pptexture.h
+++ b/src/common/rendering/vulkan/textures/vk_pptexture.h
@@ -1,12 +1,16 @@
 
 #pragma once
 
-#include "hwrenderer/postprocessing/hw_postprocess.h"
 #include <zvulkan/vulkanobjects.h>
-#include "vulkan/textures/vk_imagetransition.h"
 #include <list>
+#include <memory>
+
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
+class VulkanBuffer;
 
 class VkPPTexture : public PPTextureBackend
 {

--- a/src/common/rendering/vulkan/textures/vk_renderbuffers.cpp
+++ b/src/common/rendering/vulkan/textures/vk_renderbuffers.cpp
@@ -21,16 +21,27 @@
 */
 
 #include "vk_renderbuffers.h"
-#include "vulkan/vk_postprocess.h"
+
+#include <zvulkan/vulkanswapchain.h>
+#include <zvulkan/vulkanbuilders.h>
+#include <algorithm>
+#include <map>
+#include <memory>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/textures/vk_texture.h"
 #include "vulkan/framebuffers/vk_framebuffer.h"
-#include "vulkan/shaders/vk_shader.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vulkan/pipelines/vk_pprenderpass.h"
-#include <zvulkan/vulkanswapchain.h>
-#include <zvulkan/vulkanbuilders.h>
 #include "hw_cvars.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "engineerrors.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "vulkan/pipelines/vk_renderpass.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkRenderBuffers::VkRenderBuffers(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/textures/vk_renderbuffers.h
+++ b/src/common/rendering/vulkan/textures/vk_renderbuffers.h
@@ -3,10 +3,13 @@
 
 #include "zvulkan/vulkanobjects.h"
 #include "vulkan/textures/vk_imagetransition.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
 class VkPPRenderPassSetup;
 class PPOutput;
+class VkRenderPassKey;
+class VulkanFramebuffer;
 
 enum class WhichDepthStencil {
 	None,

--- a/src/common/rendering/vulkan/textures/vk_texture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_texture.cpp
@@ -21,11 +21,24 @@
 */
 
 #include "vk_texture.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <utility>
+
 #include "vk_hwtexture.h"
 #include "vk_pptexture.h"
 #include "vk_renderbuffers.h"
 #include "vulkan/vk_postprocess.h"
 #include "hw_cvars.h"
+#include "c_cvars.h"
+#include "engineerrors.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "vulkan/commands/vk_commandbuffer.h"
+#include "vulkan/vk_renderdevice.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/vulkanbuilders.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkTextureManager::VkTextureManager(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/textures/vk_texture.h
+++ b/src/common/rendering/vulkan/textures/vk_texture.h
@@ -2,8 +2,13 @@
 #pragma once
 
 #include <zvulkan/vulkanobjects.h>
-#include "vulkan/textures/vk_imagetransition.h"
+#include <stdint.h>
 #include <list>
+#include <memory>
+
+#include "vulkan/textures/vk_imagetransition.h"
+#include "tarray.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
 class VkHardwareTexture;
@@ -12,6 +17,8 @@ class VkPPTexture;
 class VkTextureImage;
 enum class PPTextureType;
 class PPTexture;
+class VulkanImage;
+class VulkanImageView;
 
 class VkTextureManager
 {

--- a/src/common/rendering/vulkan/vk_levelmesh.cpp
+++ b/src/common/rendering/vulkan/vk_levelmesh.cpp
@@ -21,12 +21,32 @@
 */
 
 #include "vk_levelmesh.h"
+
+#include <assert.h>
+#include <string.h>
+#include <utility>
+#include <vector>
+
 #include "zvulkan/vulkanbuilders.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "hw_levelmesh.h"
 #include "hw_material.h"
-#include "texturemanager.h"
+#include "flatvertices.h"
+#include "gametexture.h"
+#include "hw_collision.h"
+#include "hw_levelmeshlight.h"
+#include "hw_levelmeshportal.h"
+#include "hw_levelmeshsurface.h"
+#include "hw_materialstate.h"
+#include "hw_surfaceuniforms.h"
+#include "matrix.h"
+#include "textures.h"
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/volk/volk.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
 
 VkLevelMesh::VkLevelMesh(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/vk_levelmesh.h
+++ b/src/common/rendering/vulkan/vk_levelmesh.h
@@ -1,9 +1,15 @@
 
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+#include <memory>
+
 #include "zvulkan/vulkanobjects.h"
 #include "hw_levelmesh.h"
 #include "common/utility/matrix.h"
+#include "tarray.h"
+#include "vectors.h"
 
 class VulkanRenderDevice;
 

--- a/src/common/rendering/vulkan/vk_lightmapper.cpp
+++ b/src/common/rendering/vulkan/vk_lightmapper.cpp
@@ -1,5 +1,11 @@
  
 #include "vk_lightmapper.h"
+
+#include <algorithm>
+#include <functional>
+#include <string>
+#include <vector>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/textures/vk_texture.h"
 #include "vulkan/commands/vk_commandbuffer.h"
@@ -8,6 +14,18 @@
 #include "zvulkan/vulkanbuilders.h"
 #include "filesystem.h"
 #include "cmdlib.h"
+#include "c_cvars.h"
+#include "engineerrors.h"
+#include "flatvertices.h"
+#include "fs_filesystem.h"
+#include "hw_levelmesh.h"
+#include "hw_levelmeshsurface.h"
+#include "stats.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "zstring.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
 
 static int lastSurfaceCount;
 static glcycle_t lightmapRaytraceLast;

--- a/src/common/rendering/vulkan/vk_lightmapper.h
+++ b/src/common/rendering/vulkan/vk_lightmapper.h
@@ -1,8 +1,18 @@
 #pragma once
 
+#include <dp_rect_pack.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <memory>
+
 #include "common/rendering/hwrenderer/data/hw_levelmesh.h"
 #include "zvulkan/vulkanobjects.h"
-#include <dp_rect_pack.h>
+#include "hw_lightmaptile.h"
+#include "tarray.h"
+#include "vectors.h"
+#include "vulkan/vulkan_core.h"
+
+class LevelMesh;
 
 typedef dp::rect_pack::RectPacker<int> RectPacker;
 

--- a/src/common/rendering/vulkan/vk_postprocess.cpp
+++ b/src/common/rendering/vulkan/vk_postprocess.cpp
@@ -21,26 +21,30 @@
 */
 
 #include "vk_postprocess.h"
-#include "vulkan/shaders/vk_shader.h"
+
 #include <zvulkan/vulkanswapchain.h>
-#include <zvulkan/vulkanbuilders.h>
+#include <stdint.h>
+#include <algorithm>
+#include <memory>
+
 #include "vulkan/vk_renderdevice.h"
-#include "vulkan/buffers/vk_hwbuffer.h"
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vulkan/vk_renderstate.h"
 #include "vulkan/vk_pprenderstate.h"
-#include "vulkan/shaders/vk_ppshader.h"
-#include "vulkan/textures/vk_pptexture.h"
 #include "vulkan/textures/vk_renderbuffers.h"
 #include "vulkan/textures/vk_imagetransition.h"
 #include "vulkan/textures/vk_texture.h"
 #include "vulkan/framebuffers/vk_framebuffer.h"
-#include "hw_cvars.h"
 #include "hwrenderer/postprocessing/hw_postprocess.h"
 #include "hwrenderer/postprocessing/hw_postprocess_cvars.h"
 #include "hw_vrmodes.h"
-#include "flatvertices.h"
 #include "r_videoscale.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "intrect.h"
+#include "v_video.h"
+#include "vectors.h"
+#include "zvulkan/vulkanobjects.h"
 
 EXTERN_CVAR(Int, gl_dither_bpc)
 

--- a/src/common/rendering/vulkan/vk_postprocess.h
+++ b/src/common/rendering/vulkan/vk_postprocess.h
@@ -9,13 +9,15 @@
 #include "zvulkan/vulkanobjects.h"
 #include "zvulkan/vulkanbuilders.h"
 #include "vulkan/textures/vk_imagetransition.h"
+#include "vulkan/vulkan_core.h"
 
 class FString;
-
 class VkPPShader;
 class VkPPTexture;
 class PipelineBarrier;
 class VulkanRenderDevice;
+class VkTextureImage;
+struct IntRect;
 
 class VkPostprocess
 {

--- a/src/common/rendering/vulkan/vk_pprenderstate.cpp
+++ b/src/common/rendering/vulkan/vk_pprenderstate.cpp
@@ -21,21 +21,25 @@
 */
 
 #include "vk_pprenderstate.h"
+
+#include <zvulkan/vulkanswapchain.h>
+#include <memory>
+
 #include "vk_postprocess.h"
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_renderstate.h"
 #include "vulkan/commands/vk_commandbuffer.h"
-#include "vulkan/buffers/vk_buffer.h"
-#include "vulkan/shaders/vk_ppshader.h"
-#include "vulkan/textures/vk_pptexture.h"
 #include "vulkan/textures/vk_renderbuffers.h"
 #include "vulkan/textures/vk_texture.h"
-#include "vulkan/samplers/vk_samplers.h"
 #include "vulkan/framebuffers/vk_framebuffer.h"
 #include "vulkan/descriptorsets/vk_descriptorset.h"
 #include "vulkan/pipelines/vk_pprenderpass.h"
-#include <zvulkan/vulkanswapchain.h>
-#include "flatvertices.h"
+#include "tarray.h"
+#include "v_video.h"
+#include "vulkan/pipelines/vk_renderpass.h"
+#include "vulkan/shaders/vk_shader.h"
+#include "vulkan/vulkan_core.h"
+#include "zvulkan/vulkanobjects.h"
 
 VkPPRenderState::VkPPRenderState(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/common/rendering/vulkan/vk_pprenderstate.h
+++ b/src/common/rendering/vulkan/vk_pprenderstate.h
@@ -1,14 +1,19 @@
 
 #pragma once
 
-#include "hwrenderer/postprocessing/hw_postprocess.h"
 #include <zvulkan/vulkanobjects.h>
+#include <stdint.h>
+
+#include "hwrenderer/postprocessing/hw_postprocess.h"
+#include "zstring.h"
 
 class VkPPRenderPassSetup;
 class VkPPShader;
 class VkPPTexture;
 class VkTextureImage;
 class VulkanRenderDevice;
+class VulkanDescriptorSet;
+class VulkanFramebuffer;
 
 class VkPPRenderState : public PPRenderState
 {

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -21,25 +21,25 @@
 */
 
 #include <zvulkan/vulkanobjects.h>
-
 #include <inttypes.h>
+#include <zvulkan/vulkanbuilders.h>
+#include <zvulkan/vulkansurface.h>
+#include <zvulkan/vulkancompatibledevice.h>
+#include <string.h>
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "v_video.h"
 #include "m_png.h"
-
-#include "r_videoscale.h"
-#include "i_time.h"
-#include "v_text.h"
 #include "version.h"
 #include "v_draw.h"
-
 #include "hw_clock.h"
-#include "hw_vrmodes.h"
 #include "hw_cvars.h"
 #include "hw_skydome.h"
 #include "flatvertices.h"
 #include "hw_meshbuilder.h"
-
 #include "vk_renderdevice.h"
 #include "vulkan/vk_renderstate.h"
 #include "vulkan/vk_postprocess.h"
@@ -56,15 +56,37 @@
 #include "vulkan/commands/vk_commandbuffer.h"
 #include "vulkan/buffers/vk_hwbuffer.h"
 #include "vulkan/buffers/vk_buffer.h"
-#include "vulkan/buffers/vk_rsbuffers.h"
-#include <zvulkan/vulkanswapchain.h>
-#include <zvulkan/vulkanbuilders.h>
-#include <zvulkan/vulkansurface.h>
-#include <zvulkan/vulkancompatibledevice.h>
 #include "engineerrors.h"
 #include "c_dispatch.h"
 #include "menu.h"
 #include "cmdlib.h"
+#include "basics.h"
+#include "buffers.h"
+#include "c_cvars.h"
+#include "gametexture.h"
+#include "hw_aabbtree.h"
+#include "hw_levelmesh.h"
+#include "hw_material.h"
+#include "hw_materialstate.h"
+#include "hw_renderstate.h"
+#include "hw_shadowmap.h"
+#include "hw_surfaceuniforms.h"
+#include "intrect.h"
+#include "printf.h"
+#include "renderstyle.h"
+#include "stats.h"
+#include "textureid.h"
+#include "textures.h"
+#include "v_2ddrawer.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "vulkan/vulkan_core.h"
+#include "zstring.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/volk/volk.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
+
+class IHardwareTexture;
 
 FString JitCaptureStackTrace(int framesToSkip, bool includeNativeFrames, int maxFrames = -1);
 

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -1,9 +1,17 @@
 #pragma once
 
-#include "base_sysfb.h"
-#include "engineerrors.h"
 #include <zvulkan/vulkandevice.h>
 #include <zvulkan/vulkanobjects.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <functional>
+#include <memory>
+
+#include "base_sysfb.h"
+#include "engineerrors.h"
+#include "hw_lightmaptile.h"
+#include "m_png.h"
+#include "tarray.h"
 
 struct FRenderViewpoint;
 class VkSamplerManager;
@@ -24,6 +32,24 @@ class VkRenderBuffers;
 class VkPostprocess;
 class VkPipelineKey;
 class VkRenderPassSetup;
+class FCanvasTexture;
+class FGameTexture;
+class FMaterial;
+class FRenderState;
+class FTexture;
+class IBuffer;
+class IHardwareTexture;
+class LevelMesh;
+class VulkanDevice;
+class VulkanSurface;
+namespace hwrenderer {
+class LevelAABBTree;
+}  // namespace hwrenderer
+struct FMaterialState;
+struct FVertexBufferAttribute;
+struct IntRect;
+struct MeshApplyData;
+struct SurfaceUniforms;
 
 class VulkanRenderDevice : public SystemBaseFrameBuffer
 {

--- a/src/common/rendering/vulkan/vk_renderstate.cpp
+++ b/src/common/rendering/vulkan/vk_renderstate.cpp
@@ -21,6 +21,14 @@
 */
 
 #include "vk_renderstate.h"
+
+#include <zvulkan/vulkanbuilders.h>
+#include <string.h>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <vector>
+
 #include "vulkan/vk_renderdevice.h"
 #include "vulkan/vk_levelmesh.h"
 #include "vulkan/commands/vk_commandbuffer.h"
@@ -29,14 +37,35 @@
 #include "vulkan/descriptorsets/vk_descriptorset.h"
 #include "vulkan/textures/vk_renderbuffers.h"
 #include "vulkan/textures/vk_hwtexture.h"
-#include <zvulkan/vulkanbuilders.h>
-
-#include "hw_skydome.h"
 #include "hw_viewpointuniforms.h"
 #include "hw_dynlightdata.h"
 #include "hw_cvars.h"
 #include "hw_clock.h"
 #include "flatvertices.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "engineerrors.h"
+#include "gametexture.h"
+#include "hw_levelmesh.h"
+#include "hw_material.h"
+#include "hw_materialstate.h"
+#include "hw_surfaceuniforms.h"
+#include "palentry.h"
+#include "renderstyle.h"
+#include "stats.h"
+#include "textures.h"
+#include "v_video.h"
+#include "vectors.h"
+#include "vulkan/buffers/vk_hwbuffer.h"
+#include "vulkan/buffers/vk_rsbuffers.h"
+#include "vulkan/textures/vk_imagetransition.h"
+#include "zvulkan/vk_mem_alloc/vk_mem_alloc.h"
+#include "zvulkan/volk/volk.h"
+#include "zvulkan/vulkandevice.h"
+#include "zvulkan/vulkaninstance.h"
+#include "zvulkan/vulkanobjects.h"
+
+class IBuffer;
 
 CVAR(Int, vk_submit_size, 1000, 0);
 EXTERN_CVAR(Bool, r_skipmats)

--- a/src/common/rendering/vulkan/vk_renderstate.h
+++ b/src/common/rendering/vulkan/vk_renderstate.h
@@ -1,18 +1,29 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <utility>
+
 #include "vulkan/buffers/vk_hwbuffer.h"
 #include "vulkan/buffers/vk_rsbuffers.h"
 #include "vulkan/shaders/vk_shader.h"
 #include "vulkan/pipelines/vk_renderpass.h"
-
 #include "name.h"
-
 #include "hw_renderstate.h"
 #include "hw_material.h"
+#include "flatvertices.h"
+#include "matrix.h"
+#include "tarray.h"
+#include "vulkan/vulkan_core.h"
 
 class VulkanRenderDevice;
 class VkTextureImage;
+class IBuffer;
+class VkRSBuffers;
+class VulkanCommandBuffer;
+class VulkanImageView;
+struct FDynLightData;
+struct HWViewpointUniforms;
 
 class VkRenderState : public FRenderState
 {

--- a/src/common/textures/gametexture.h
+++ b/src/common/textures/gametexture.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <memory>
 #include "vectors.h"
+#include "textures.h"
 #include "floatrect.h"
 #include "refcounted.h"
 #include "xs_Float.h"
@@ -11,7 +12,6 @@
 
 // 15 because 0th texture is our texture
 #define MAX_CUSTOM_HW_SHADER_TEXTURES 15
-class FTexture;
 class ISoftwareTexture;
 class FMaterial;
 

--- a/src/common/textures/hires/hqnx/hq2x.cpp
+++ b/src/common/textures/hires/hqnx/hq2x.cpp
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include <stdint.h>
+
 #include "common.h"
 #include "hqx.h"
 

--- a/src/common/textures/hires/hqnx/hq3x.cpp
+++ b/src/common/textures/hires/hqnx/hq3x.cpp
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include <stdint.h>
+
 #include "common.h"
 #include "hqx.h"
 

--- a/src/common/textures/hires/hqnx/hq4x.cpp
+++ b/src/common/textures/hires/hqnx/hq4x.cpp
@@ -18,6 +18,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include <stdint.h>
+
 #include "common.h"
 #include "hqx.h"
 

--- a/src/common/textures/hires/hqnx/init.cpp
+++ b/src/common/textures/hires/hqnx/init.cpp
@@ -16,6 +16,8 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 
+#include <stdint.h>
+
 #include "hqx.h"
 
 uint32_t   *RGBtoYUV;

--- a/src/common/textures/hires/hqnx_asm/hq2x_asm.cpp
+++ b/src/common/textures/hires/hqnx_asm/hq2x_asm.cpp
@@ -18,6 +18,7 @@
 //Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "hqnx_asm.h"
+#include "hqnx_asm/hqnx_asm_Image.h"
 
 namespace HQnX_asm
 {

--- a/src/common/textures/hires/hqnx_asm/hq3x_asm.cpp
+++ b/src/common/textures/hires/hqnx_asm/hq3x_asm.cpp
@@ -18,6 +18,7 @@
 //Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "hqnx_asm.h"
+#include "hqnx_asm/hqnx_asm_Image.h"
 
 namespace HQnX_asm
 {

--- a/src/common/textures/hires/hqnx_asm/hq4x_asm.cpp
+++ b/src/common/textures/hires/hqnx_asm/hq4x_asm.cpp
@@ -19,6 +19,7 @@
 
 
 #include "hqnx_asm.h"
+#include "hqnx_asm/hqnx_asm_Image.h"
 
 namespace HQnX_asm
 {

--- a/src/common/textures/hires/hqresize.cpp
+++ b/src/common/textures/hires/hqresize.cpp
@@ -36,10 +36,19 @@
 
 #include "c_cvars.h"
 #include "hqnx/hqx.h"
+#include "gametexture.h"
+#include "hqnx_asm/hqnx_asm_Image.h"
+#include "xbr/xbrz_config.h"
+#include "xbr/xbrz_config_old.h"
 #ifdef HAVE_MMX
 #include "hqnx_asm/hqnx_asm.h"
 #endif
+#include <stddef.h>
+#include <stdint.h>
 #include <memory>
+#include <algorithm>
+#include <limits>
+
 #include "xbr/xbrz.h"
 #include "xbr/xbrz_old.h"
 #include "parallel_for.h"

--- a/src/common/textures/hires/xbr/xbrz.cpp
+++ b/src/common/textures/hires/xbr/xbrz.cpp
@@ -15,11 +15,14 @@
 // ****************************************************************************
 
 #include "xbrz.h"
+
 #include <cassert>
 #include <vector>
 #include <algorithm>
 #include <cmath> //std::sqrt
+
 #include "xbrz_tools.h"
+#include "xbr/xbrz_config.h"
 
 using namespace xbrz;
 

--- a/src/common/textures/hires/xbr/xbrz_old.cpp
+++ b/src/common/textures/hires/xbr/xbrz_old.cpp
@@ -15,9 +15,13 @@
 
 #include "xbrz_old.h"
 
+#include <bits/std_abs.h>
 #include <cassert>
 #include <cmath>
 #include <algorithm>
+#include <type_traits>
+
+#include "xbr/xbrz_config_old.h"
 
 namespace
 {

--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -33,11 +33,14 @@
 */
 
 #include "findfile.h"
+
+#include <dirent.h>
+#include <stddef.h>
+
 #include "zstring.h"
 #include "cmdlib.h"
 #include "printf.h"
 #include "configfile.h"
-#include "i_system.h"
 #include "fs_findfile.h"
 
 #ifdef __unix__

--- a/src/common/utility/matrix.cpp
+++ b/src/common/utility/matrix.cpp
@@ -10,8 +10,8 @@ This is a simplified version of VSMatrix that has been adjusted for GZDoom's nee
 
 ----------------------------------------------------*/
 
-#include <algorithm>
-#include <math.h>
+#include <cmath>
+
 #include "matrix.h"
 
 #ifdef _MSC_VER

--- a/src/common/utility/matrix.h
+++ b/src/common/utility/matrix.h
@@ -21,6 +21,10 @@
 #define __VSMatrix__
 
 #include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <xmmintrin.h>
+
 #include "vectors.h"
 
 #ifdef USE_DOUBLE

--- a/src/common/utility/x86.cpp
+++ b/src/common/utility/x86.cpp
@@ -32,9 +32,10 @@
 **
 */
 
-#include <stdlib.h>
 #include <string.h>
+
 #include "x86.h"
+#include "basics.h"
 
 CPUInfo CPU;
 
@@ -54,7 +55,6 @@ FString DumpCPUInfo(const CPUInfo *cpu, bool brief)
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
-#include <emmintrin.h>
 
 
 #ifdef __GNUC__

--- a/src/common/utility/x86.h
+++ b/src/common/utility/x86.h
@@ -1,6 +1,8 @@
 #ifndef X86_H
 #define X86_H
 
+#include <stdint.h>
+
 #include "basics.h"
 #include "zstring.h"
 

--- a/src/common/utility/zstring.h
+++ b/src/common/utility/zstring.h
@@ -37,7 +37,11 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stddef.h>
+#include <assert.h>
+#include <stdint.h>
 #include <string>
+#include <utility>
+
 #include "tarray.h"
 #include "utf8.h"
 #include "filesystem.h"

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -49,6 +49,7 @@ enum
 };
 
 struct subsector_t;
+struct sector_t;
 struct FLevelLocals;
 
 // [RH] Particle details

--- a/src/posix/i_steam.cpp
+++ b/src/posix/i_steam.cpp
@@ -33,15 +33,17 @@
 */
 
 #include <sys/stat.h>
+#include <stdlib.h>
 
 #ifdef __APPLE__
 #include "m_misc.h"
 #endif // __APPLE__
 
 #include "engineerrors.h"
-#include "d_main.h"
 #include "sc_man.h"
 #include "cmdlib.h"
+#include "tarray.h"
+#include "zstring.h"
 
 static void PSR_FindEndBlock(FScanner &sc)
 {

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -25,12 +25,16 @@
 **
 **/
 
-#include "p_lnspec.h"
-#include "p_local.h"
-#include "a_sharedglobal.h"
+#include <assert.h>
+#include <emmintrin.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <atomic>
+#include <future>
+
 #include "g_levellocals.h"
 #include "p_effect.h"
-#include "po_man.h"
 #include "m_fixed.h"
 #include "ctpl.h"
 #include "texturemanager.h"
@@ -40,14 +44,26 @@
 #include "hwrenderer/scene/hw_drawinfo.h"
 #include "hwrenderer/scene/hw_portal.h"
 #include "hw_clock.h"
-#include "flatvertices.h"
 #include "hw_vertexbuilder.h"
 #include "hw_walldispatcher.h"
 #include "hw_flatdispatcher.h"
+#include "actor.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "dobjgc.h"
+#include "doomdata.h"
+#include "gametexture.h"
+#include "info.h"
+#include "portal.h"
+#include "r_defs.h"
+#include "r_sections.h"
+#include "r_utility.h"
+#include "stats.h"
+#include "tarray.h"
+#include "v_video.h"
+#include "vectors.h"
 
-#ifdef ARCH_IA32
-#include <immintrin.h>
-#endif // ARCH_IA32
+class FRenderState;
 
 CVAR(Bool, gl_multithread, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 

--- a/src/rendering/hwrenderer/scene/hw_clipper.cpp
+++ b/src/rendering/hwrenderer/scene/hw_clipper.cpp
@@ -36,8 +36,14 @@
 */
 
 #include "hw_clipper.h"
-#include "g_levellocals.h"
+
+#include <math.h>
+#include <stdint.h>
+
 #include "basics.h"
+#include "m_bbox.h"
+#include "r_utility.h"
+#include "xs_Float.h"
 
 //-----------------------------------------------------------------------------
 //

--- a/src/rendering/hwrenderer/scene/hw_clipper.h
+++ b/src/rendering/hwrenderer/scene/hw_clipper.h
@@ -1,9 +1,15 @@
 #pragma once
 
+#include <stddef.h>
+
 #include "doomtype.h"
 #include "xs_Float.h"
 #include "r_utility.h"
 #include "memarena.h"
+#include "basics.h"
+#include "r_defs.h"
+
+struct FRenderViewpoint;
 
 class ClipNode
 {

--- a/src/rendering/hwrenderer/scene/hw_decal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_decal.cpp
@@ -25,11 +25,12 @@
 **
 */
 
+#include <string.h>
+#include <utility>
+
 #include "doomdata.h"
 #include "a_sharedglobal.h"
-#include "r_utility.h"
 #include "g_levellocals.h"
-#include "hw_material.h"
 #include "hw_cvars.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hwrenderer/scene/hw_drawinfo.h"
@@ -39,6 +40,23 @@
 #include "flatvertices.h"
 #include "hw_renderstate.h"
 #include "texturemanager.h"
+#include "actor.h"
+#include "c_cvars.h"
+#include "doom_levelmesh.h"
+#include "fcolormap.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "hw_lightmaptile.h"
+#include "p_3dfloors.h"
+#include "palentry.h"
+#include "palettecontainer.h"
+#include "r_defs.h"
+#include "renderstyle.h"
+#include "scene/hw_portal.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
+#include "vectors.h"
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_drawcontext.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawcontext.cpp
@@ -1,6 +1,9 @@
 
 #include "hw_drawcontext.h"
+
 #include "hw_drawinfo.h"
+#include "r_defs.h"
+#include "tarray.h"
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_drawcontext.h
+++ b/src/rendering/hwrenderer/scene/hw_drawcontext.h
@@ -3,11 +3,15 @@
 #include "common/utility/tarray.h"
 #include "hw_clipper.h"
 #include "hw_portal.h"
+#include "memarena.h"
+#include "scene/hw_drawinfo.h"
+#include "scene/hw_drawlist.h"
 
 struct HWDrawInfo;
 struct SortNode;
 struct FDynamicLight;
 class HWDrawContext;
+struct sector_t;
 
 class FDrawInfoList
 {

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -25,9 +25,15 @@
 **
 */
 
-#include "a_sharedglobal.h"
+#include <assert.h>
+#include <bits/std_abs.h>
+#include <limits.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
 #include "r_utility.h"
-#include "r_sky.h"
 #include "d_player.h"
 #include "g_levellocals.h"
 #include "hw_fakeflat.h"
@@ -36,7 +42,6 @@
 #include "hw_drawinfo.h"
 #include "hw_drawcontext.h"
 #include "hw_walldispatcher.h"
-#include "po_man.h"
 #include "models.h"
 #include "hw_clock.h"
 #include "hw_cvars.h"
@@ -46,8 +51,39 @@
 #include "v_draw.h"
 #include "texturemanager.h"
 #include "actorinlines.h"
-#include "g_levellocals.h"
 #include "hw_lighting.h"
+#include "hwrenderer/scene/hw_drawinfo.h"
+#include "actor.h"
+#include "dobject.h"
+#include "dobjgc.h"
+#include "doomdata.h"
+#include "doomstat.h"
+#include "dthinker.h"
+#include "fcolormap.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "hw_texcontainer.h"
+#include "info.h"
+#include "intrect.h"
+#include "m_fixed.h"
+#include "matrix.h"
+#include "memarena.h"
+#include "name.h"
+#include "p_3dfloors.h"
+#include "p_trace.h"
+#include "palutil.h"
+#include "portal.h"
+#include "r_sections.h"
+#include "r_state.h"
+#include "renderstyle.h"
+#include "scene/hw_drawlist.h"
+#include "scene/hw_drawstructs.h"
+#include "scene/hw_weapon.h"
+#include "sprites.h"
+#include "stats.h"
+#include "textureid.h"
+#include "textures.h"
+#include "v_video.h"
 
 EXTERN_CVAR(Float, r_visibility)
 EXTERN_CVAR(Int, lm_background_updates);

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <stdint.h>
 #include <atomic>
 #include <functional>
+
 #include "vectors.h"
 #include "r_defs.h"
 #include "r_utility.h"
@@ -11,6 +13,24 @@
 #include "hw_drawlist.h"
 #include "hw_renderstate.h"
 #include "g_levellocals.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "doom_levelmesh.h"
+#include "doomtype.h"
+#include "files.h"
+#include "hw_levelmeshsurface.h"
+#include "hw_lightmaptile.h"
+#include "palentry.h"
+#include "tarray.h"
+
+class AActor;
+class player_t;
+namespace FileSys {
+class FileWriter;
+}  // namespace FileSys
+struct FColormap;
+struct FLightNode;
+struct IntRect;
 
 EXTERN_CVAR(Bool, lm_always_update);
 EXTERN_CVAR(Int, lm_max_updates);

--- a/src/rendering/hwrenderer/scene/hw_drawlist.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawlist.cpp
@@ -25,21 +25,28 @@
 **
 */
 
-#include "r_sky.h"
+#include <float.h>
+#include <limits.h>
+#include <string.h>
+#include <algorithm>
+#include <cmath>
+
 #include "r_utility.h"
-#include "doomstat.h"
 #include "actor.h"
 #include "g_levellocals.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hwrenderer/scene/hw_drawlist.h"
-#include "flatvertices.h"
 #include "hw_clock.h"
 #include "hw_renderstate.h"
 #include "hw_drawinfo.h"
-#include "hw_fakeflat.h"
 #include "hw_drawcontext.h"
 #include "hw_walldispatcher.h"
 #include "hw_flatdispatcher.h"
+#include "c_cvars.h"
+#include "doomdef.h"
+#include "memarena.h"
+#include "stats.h"
+#include "tflags.h"
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_drawlist.h
+++ b/src/rendering/hwrenderer/scene/hw_drawlist.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "memarena.h"
+#include "tarray.h"
 
 struct HWDrawInfo;
 class HWWall;

--- a/src/rendering/hwrenderer/scene/hw_fakeflat.cpp
+++ b/src/rendering/hwrenderer/scene/hw_fakeflat.cpp
@@ -25,18 +25,20 @@
 **
 */
 
-#include "p_lnspec.h"
-#include "p_local.h"
+#include <assert.h>
+#include <string.h>
+
 #include "g_levellocals.h"
-#include "a_sharedglobal.h"
-#include "d_player.h"
 #include "r_sky.h"
 #include "hw_fakeflat.h"
-#include "hw_drawinfo.h"
-#include "hw_cvars.h"
 #include "hw_drawcontext.h"
-#include "r_utility.h"
 #include "texturemanager.h"
+#include "gametexture.h"
+#include "memarena.h"
+#include "portal.h"
+#include "r_defs.h"
+#include "tarray.h"
+#include "textureid.h"
 
 extern thread_local bool isWorkerThread;
 

--- a/src/rendering/hwrenderer/scene/hw_fakeflat.h
+++ b/src/rendering/hwrenderer/scene/hw_fakeflat.h
@@ -1,6 +1,9 @@
 #pragma once
 
 class HWDrawContext;
+struct sector_t;
+struct side_t;
+struct vertex_t;
 
 enum area_t : int
 {

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -25,22 +25,23 @@
 **
 */
 
-#include "a_sharedglobal.h"
+#include <float.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <utility>
+
 #include "a_dynlight.h"
 #include "r_defs.h"
 #include "r_sky.h"
 #include "r_utility.h"
-#include "doomstat.h"
-#include "d_player.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "p_lnspec.h"
 #include "matrix.h"
 #include "hw_dynlightdata.h"
 #include "hw_cvars.h"
 #include "hw_clock.h"
 #include "hw_lighting.h"
-#include "hw_material.h"
 #include "hw_drawcontext.h"
 #include "hwrenderer/scene/hw_drawinfo.h"
 #include "flatvertices.h"
@@ -48,6 +49,23 @@
 #include "hw_renderstate.h"
 #include "texturemanager.h"
 #include "hw_flatdispatcher.h"
+#include "c_cvars.h"
+#include "doom_levelmesh.h"
+#include "fcolormap.h"
+#include "gametexture.h"
+#include "p_3dfloors.h"
+#include "palentry.h"
+#include "palettecontainer.h"
+#include "r_sections.h"
+#include "renderstyle.h"
+#include "scene/hw_portal.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
+#include "vectors.h"
+#include "xs_Float.h"
+
+struct FSectorPortal;
 
 #ifdef _DEBUG
 CVAR(Int, gl_breaksec, -1, 0)

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -25,11 +25,15 @@
 **
 */
 
+#include <stddef.h>
+#include <stdint.h>
+#include <cmath>
+#include <utility>
+
 #include "c_dispatch.h"
 #include "p_maputl.h"
 #include "hw_portal.h"
 #include "hw_clipper.h"
-#include "d_player.h"
 #include "r_sky.h"
 #include "g_levellocals.h"
 #include "hw_renderstate.h"
@@ -38,6 +42,21 @@
 #include "hw_lighting.h"
 #include "hw_drawcontext.h"
 #include "texturemanager.h"
+#include "c_cvars.h"
+#include "dobjgc.h"
+#include "gametexture.h"
+#include "matrix.h"
+#include "palettecontainer.h"
+#include "printf.h"
+#include "r_utility.h"
+#include "renderstyle.h"
+#include "scene/hw_drawinfo.h"
+#include "scene/hw_drawstructs.h"
+#include "stats.h"
+#include "textures.h"
+#include "tflags.h"
+#include "v_video.h"
+#include "zstring.h"
 
 EXTERN_CVAR(Int, r_mirror_recursions)
 EXTERN_CVAR(Bool, gl_portals)

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include "tarray.h"
 #include "r_utility.h"
 #include "r_sections.h"
@@ -8,8 +10,19 @@
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hw_renderstate.h"
 #include "hw_material.h"
+#include "basics.h"
+#include "fcolormap.h"
+#include "palentry.h"
+#include "portal.h"
+#include "r_defs.h"
+#include "textureid.h"
+#include "vectors.h"
 
 class FSkyBox;
+class Clipper;
+class FGameTexture;
+class FSkyVertexBuffer;
+struct FRenderViewpoint;
 
 struct HWSkyInfo
 {

--- a/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
+++ b/src/rendering/hwrenderer/scene/hw_renderhacks.cpp
@@ -25,24 +25,34 @@
 **
 */
 
-#include "a_sharedglobal.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <utility>
+
 #include "a_dynlight.h"
 #include "r_utility.h"
 #include "r_sky.h"
 #include "g_levellocals.h"
-#include "a_dynlight.h"
 #include "texturemanager.h"
-
 #include "hw_drawcontext.h"
 #include "hw_drawinfo.h"
 #include "hw_drawstructs.h"
 #include "hw_clock.h"
 #include "hw_dynlightdata.h"
 #include "flatvertices.h"
-#include "hwrenderer/scene/hw_portal.h"
 #include "hw_fakeflat.h"
 #include "hw_walldispatcher.h"
 #include "hw_flatdispatcher.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "hw_renderstate.h"
+#include "memarena.h"
+#include "p_3dfloors.h"
+#include "r_defs.h"
+#include "r_sections.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "vectors.h"
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -20,9 +20,9 @@
 //--------------------------------------------------------------------------
 //
 
-#include "a_sharedglobal.h"
+#include <string.h>
+
 #include "r_sky.h"
-#include "r_state.h"
 #include "r_utility.h"
 #include "doomdata.h"
 #include "g_levellocals.h"
@@ -31,9 +31,21 @@
 #include "hwrenderer/scene/hw_drawinfo.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hwrenderer/scene/hw_portal.h"
-#include "hw_lighting.h"
-#include "hw_material.h"
 #include "hw_walldispatcher.h"
+#include "c_cvars.h"
+#include "dobjgc.h"
+#include "doomdef.h"
+#include "fcolormap.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "palentry.h"
+#include "portal.h"
+#include "r_defs.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "v_video.h"
+
+class FRenderState;
 
 CVAR(Bool,gl_noskyboxes, false, 0)
 

--- a/src/rendering/hwrenderer/scene/hw_skyportal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_skyportal.cpp
@@ -20,16 +20,20 @@
 //--------------------------------------------------------------------------
 //
 
-#include "doomtype.h"
-#include "g_level.h"
-#include "filesystem.h"
-#include "r_state.h"
-#include "r_utility.h"
+#include <algorithm>
+
 #include "g_levellocals.h"
 #include "hw_skydome.h"
 #include "hwrenderer/scene/hw_portal.h"
 #include "hw_renderstate.h"
 #include "skyboxtexture.h"
+#include "basics.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "palentry.h"
+#include "renderstyle.h"
+#include "scene/hw_drawinfo.h"
+#include "textures.h"
 
 //-----------------------------------------------------------------------------
 //

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -25,20 +25,30 @@
 **
 */
 
-#include "c_dispatch.h"
-#include "a_dynlight.h" 
-#include "p_local.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <cmath>	// needed for std::floor on mac
+#include <algorithm>
+
+#include "a_dynlight.h"
 #include "p_effect.h"
-#include "g_level.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "hw_drawcontext.h"
 #include "hw_dynlightdata.h"
 #include "hw_shadowmap.h"
 #include "hwrenderer/scene/hw_drawinfo.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "models.h"
-#include <cmath>	// needed for std::floor on mac
+#include "actor.h"
+#include "dobjgc.h"
+#include "doom_levelmesh.h"
+#include "portal.h"
+#include "r_defs.h"
+#include "r_sections.h"
+#include "r_utility.h"
+#include "tarray.h"
+#include "v_video.h"
+#include "vectors.h"
 
 template<class T>
 T smoothstep(const T edge0, const T edge1, const T x)

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -25,17 +25,17 @@
 **
 */
 
-#include "p_local.h"
+#include <float.h>
+#include <stdint.h>
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
 #include "p_effect.h"
-#include "g_level.h"
-#include "doomstat.h"
 #include "r_defs.h"
-#include "r_sky.h"
 #include "r_utility.h"
-#include "a_pickups.h"
 #include "d_player.h"
 #include "g_levellocals.h"
-#include "events.h"
 #include "actorinlines.h"
 #include "r_data/r_vanillatrans.h"
 #include "matrix.h"
@@ -43,7 +43,6 @@
 #include "vectors.h"
 #include "texturemanager.h"
 #include "basics.h"
-
 #include "hw_models.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hwrenderer/scene/hw_drawinfo.h"
@@ -53,11 +52,33 @@
 #include "hw_cvars.h"
 #include "hw_clock.h"
 #include "hw_lighting.h"
-#include "hw_material.h"
 #include "hw_dynlightdata.h"
 #include "hw_renderstate.h"
 #include "hw_drawcontext.h"
 #include "quaternion.h"
+#include "actor.h"
+#include "animations.h"
+#include "c_cvars.h"
+#include "dobjgc.h"
+#include "fcolormap.h"
+#include "floatrect.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "hw_texcontainer.h"
+#include "i_interface.h"
+#include "model.h"
+#include "name.h"
+#include "p_3dfloors.h"
+#include "palentry.h"
+#include "palettecontainer.h"
+#include "portal.h"
+#include "renderstyle.h"
+#include "sprites.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
+#include "tflags.h"
+#include "v_draw.h"
 
 extern TArray<spritedef_t> sprites;
 extern TArray<spriteframe_t> SpriteFrames;

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -20,20 +20,21 @@
 //--------------------------------------------------------------------------
 //
 
-#include "p_local.h"
+#include <assert.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <algorithm>
+
 #include "p_lnspec.h"
 #include "a_dynlight.h"
-#include "a_sharedglobal.h"
 #include "r_defs.h"
 #include "r_sky.h"
 #include "r_utility.h"
-#include "p_maputl.h"
 #include "doomdata.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "texturemanager.h"
 #include "hw_dynlightdata.h"
-#include "hw_material.h"
 #include "hw_cvars.h"
 #include "hw_clock.h"
 #include "hw_lighting.h"
@@ -42,8 +43,28 @@
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "hwrenderer/scene/hw_portal.h"
 #include "hw_renderstate.h"
-#include "hw_skydome.h"
 #include "hw_walldispatcher.h"
+#include "basics.h"
+#include "c_cvars.h"
+#include "doom_levelmesh.h"
+#include "doomdef.h"
+#include "fcolormap.h"
+#include "floatrect.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "matrix.h"
+#include "p_3dfloors.h"
+#include "palentry.h"
+#include "palettecontainer.h"
+#include "portal.h"
+#include "r_sections.h"
+#include "renderstyle.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
+#include "v_video.h"
+#include "vectors.h"
+#include "xs_Float.h"
 
 void SetGlowPlanes(FRenderState &state, const secplane_t& top, const secplane_t& bottom)
 {

--- a/src/rendering/hwrenderer/scene/hw_walls_vertex.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls_vertex.cpp
@@ -21,13 +21,19 @@
 //
 
 
+#include <stddef.h>
+#include <utility>
+
 #include "r_defs.h"
 #include "flatvertices.h"
 #include "hw_renderstate.h"
-#include "hwrenderer/scene/hw_drawinfo.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "doom_levelmesh.h"
 #include "g_levellocals.h"
+#include "c_cvars.h"
+#include "hw_lightmaptile.h"
+#include "tarray.h"
+#include "vectors.h"
 
 EXTERN_CVAR(Bool, gl_seamless)
 

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -25,7 +25,8 @@
 **
 */
 
-#include "sbar.h"
+#include <utility>
+
 #include "r_utility.h"
 #include "v_video.h"
 #include "doomstat.h"
@@ -35,18 +36,36 @@
 #include "hw_weapon.h"
 #include "hw_fakeflat.h"
 #include "texturemanager.h"
-
 #include "hw_models.h"
 #include "hw_dynlightdata.h"
-#include "hw_material.h"
 #include "hw_lighting.h"
 #include "hw_cvars.h"
 #include "hwrenderer/scene/hw_drawinfo.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
 #include "flatvertices.h"
 #include "hw_renderstate.h"
-
 #include "vm.h"
+#include "a_pickups.h"
+#include "actor.h"
+#include "base_sbar.h"
+#include "c_cvars.h"
+#include "dobject.h"
+#include "dobjgc.h"
+#include "floatrect.h"
+#include "g_mapinfo.h"
+#include "gametexture.h"
+#include "hw_texcontainer.h"
+#include "info.h"
+#include "name.h"
+#include "p_3dfloors.h"
+#include "p_pspr.h"
+#include "palettecontainer.h"
+#include "r_defs.h"
+#include "r_state.h"
+#include "sprites.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
 
 EXTERN_CVAR(Float, transsouls)
 EXTERN_CVAR(Int, gl_fuzztype)

--- a/src/rendering/hwrenderer/scene/hw_weapon.h
+++ b/src/rendering/hwrenderer/scene/hw_weapon.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "vectors.h"
+#include "fcolormap.h"
+#include "palentry.h"
+#include "renderstyle.h"
 
 class DPSprite;
 class player_t;
@@ -9,6 +12,8 @@ enum area_t : int;
 struct FSpriteModelFrame;
 struct HWDrawInfo;
 class FGameTexture;
+class FRenderState;
+struct sector_t;
 
 
 struct WeaponPosition2D

--- a/src/rendering/swrenderer/r_swscene.cpp
+++ b/src/rendering/swrenderer/r_swscene.cpp
@@ -25,12 +25,13 @@
 **
 */
 
+#include <stddef.h>
+#include <functional>
+
 #include "hw_ihwtexture.h"
 #include "hw_material.h"
 #include "swrenderer/r_renderer.h"
 #include "r_swscene.h"
-#include "filesystem.h"
-#include "d_player.h"
 #include "bitmap.h"
 #include "swrenderer/scene/r_light.h"
 #include "image.h"
@@ -38,6 +39,19 @@
 #include "texturemanager.h"
 #include "d_main.h"
 #include "v_draw.h"
+#include "gametexture.h"
+#include "palentry.h"
+#include "palettecontainer.h"
+#include "palutil.h"
+#include "r_utility.h"
+#include "tarray.h"
+#include "textureid.h"
+#include "textures.h"
+#include "v_2ddrawer.h"
+#include "v_video.h"
+
+class player_t;
+struct sector_t;
 
 class FSWPaletteTexture : public FImageSource
 {

--- a/src/rendering/swrenderer/r_swscene.h
+++ b/src/rendering/swrenderer/r_swscene.h
@@ -1,15 +1,20 @@
 #pragma once
 #pragma once
 
+#include <memory>
+
 #include "r_defs.h"
 #include "m_fixed.h"
 #include "hwrenderer/scene/hw_clipper.h"
 #include "r_utility.h"
 #include "c_cvars.h"
-#include <memory>
 
 class FWrapperTexture;
 class DCanvas;
+class FGameTexture;
+class FTexture;
+class player_t;
+struct sector_t;
 
 class SWSceneDrawer
 {


### PR DESCRIPTION
This is mostly autogenerated and despite the size of the diff I didn't really spend longer than an hour on this so I won't mind if this is insta-rejected due to being too noisy lmao

Used https://github.com/include-what-you-use/include-what-you-use to automatically detect includes that aren't doing anything and things that are only included transitively, and applied their fixing tool (with some manual cleanup afterwards since the output had a couple problems, though only a single digit number of them, fairly impressive to be honest)

hopefully this passes the CI lol