### PR TITLE
Fix Specular not using Material definition for Glossiness and Level

### DIFF
--- a/wadsrc/static/shaders/scene/lightmodel_specular.glsl
+++ b/wadsrc/static/shaders/scene/lightmodel_specular.glsl
@@ -1,5 +1,5 @@
 
-vec2 lightAttenuation(int i, vec3 normal, vec3 viewdir, float lightcolorA)
+vec2 lightAttenuation(int i, vec3 normal, vec3 viewdir, float lightcolorA, float glossiness, float specularLevel)
 {
 	vec4 lightpos = lights[i];
 	vec4 lightspot1 = lights[i+2];
@@ -25,9 +25,6 @@ vec2 lightAttenuation(int i, vec3 normal, vec3 viewdir, float lightcolorA)
 	if (attenuation <= 0.0)
 		return vec2(0.0);
 
-	float glossiness = uSpecularMaterial.x;
-	float specularLevel = uSpecularMaterial.y;
-
 	vec3 halfdir = normalize(viewdir + lightdir);
 	float specAngle = clamp(dot(halfdir, normal), 0.0f, 1.0f);
 	float phExp = glossiness * 4.0f;
@@ -51,7 +48,7 @@ vec3 ProcessMaterialLight(Material material, vec3 color)
 			for(int i=lightRange.x; i<lightRange.y; i+=4)
 			{
 				vec4 lightcolor = lights[i+1];
-				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a);
+				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a, material.Glossiness, material.SpecularLevel);
 				dynlight.rgb += lightcolor.rgb * attenuation.x;
 				specular.rgb += lightcolor.rgb * attenuation.y;
 			}
@@ -60,7 +57,7 @@ vec3 ProcessMaterialLight(Material material, vec3 color)
 			for(int i=lightRange.y; i<lightRange.z; i+=4)
 			{
 				vec4 lightcolor = lights[i+1];
-				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a);
+				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a, material.Glossiness, material.SpecularLevel);
 				dynlight.rgb -= lightcolor.rgb * attenuation.x;
 				specular.rgb -= lightcolor.rgb * attenuation.y;
 			}
@@ -99,7 +96,7 @@ vec3 ProcessMaterialLight(Material material, vec3 color)
 			for(int i=lightRange.z; i<lightRange.w; i+=4)
 			{
 				vec4 lightcolor = lights[i+1];
-				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a);
+				vec2 attenuation = lightAttenuation(i, normal, viewdir, lightcolor.a, material.Glossiness, material.SpecularLevel);
 				addlight.rgb += lightcolor.rgb * attenuation.x;
 			}
 


### PR DESCRIPTION
For a long time now specular materials have not been able to have their glossiness and level changed outside of the initial GLDEFS and within a custom shader file definition due to an oversight in their underlying shader code. This pull request fixes that.

- Ashley (Dark Assassin)