### PR TITLE
Added toggle for lm_dynamic sectors

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_lightmaptile.h
+++ b/src/common/rendering/hwrenderer/data/hw_lightmaptile.h
@@ -54,7 +54,7 @@ struct LightmapTile
 	// True if the tile needs to be rendered into the lightmap texture before it can be used
 	bool NeedsUpdate = true;
 
-	bool AlwaysUpdate = false;
+	uint8_t AlwaysUpdate = 0;
 
 	FVector2 ToUV(const FVector3& vert) const
 	{

--- a/src/common/rendering/vulkan/vk_lightmapper.cpp
+++ b/src/common/rendering/vulkan/vk_lightmapper.cpp
@@ -29,6 +29,7 @@ CVAR(Bool, lm_blur, true, CVAR_ARCHIVE);
 CVAR(Bool, lm_ao, false, CVAR_ARCHIVE);
 CVAR(Bool, lm_softshadows, true, CVAR_ARCHIVE);
 CVAR(Bool, lm_bounce, false, CVAR_ARCHIVE);
+CVAR(Bool, lm_dynamic, true, CVAR_ARCHIVE);
 
 VkLightmapper::VkLightmapper(VulkanRenderDevice* fb) : fb(fb)
 {

--- a/src/rendering/hwrenderer/doom_levelmesh.cpp
+++ b/src/rendering/hwrenderer/doom_levelmesh.cpp
@@ -1052,7 +1052,7 @@ void DoomLevelMesh::CreateWallSurface(side_t* side, HWWallDispatcher& disp, Mesh
 			tile.Bounds = sinfo.Surface->Bounds;
 			tile.Plane = sinfo.Surface->Plane;
 			tile.SampleDimension = GetSampleDimension(sampleDimension);
-			tile.AlwaysUpdate = true;
+			tile.AlwaysUpdate = 2; // Ignore lm_dynamic
 
 			sinfo.Surface->LightmapTileIndex = Lightmap.Tiles.Size();
 			Lightmap.Tiles.Push(tile);
@@ -1153,7 +1153,7 @@ void DoomLevelMesh::SortDrawLists()
 	memcpy(Mesh.DrawIndexes.Data(), indexes.Data(), indexes.Size() * sizeof(uint32_t));
 }
 
-int DoomLevelMesh::AddSurfaceToTile(const DoomSurfaceInfo& info, const LevelMeshSurface& surf, uint16_t sampleDimension, bool alwaysUpdate)
+int DoomLevelMesh::AddSurfaceToTile(const DoomSurfaceInfo& info, const LevelMeshSurface& surf, uint16_t sampleDimension, uint8_t alwaysUpdate)
 {
 	if (surf.IsSky)
 		return -1;
@@ -1177,7 +1177,7 @@ int DoomLevelMesh::AddSurfaceToTile(const DoomSurfaceInfo& info, const LevelMesh
 			tile.Bounds.max.X = std::max(tile.Bounds.max.X, surf.Bounds.max.X);
 			tile.Bounds.max.Y = std::max(tile.Bounds.max.Y, surf.Bounds.max.Y);
 			tile.Bounds.max.Z = std::max(tile.Bounds.max.Z, surf.Bounds.max.Z);
-			tile.AlwaysUpdate = tile.AlwaysUpdate || alwaysUpdate;
+			tile.AlwaysUpdate = max<uint8_t>(tile.AlwaysUpdate, alwaysUpdate);
 		}
 
 		return index;

--- a/src/rendering/hwrenderer/doom_levelmesh.h
+++ b/src/rendering/hwrenderer/doom_levelmesh.h
@@ -169,7 +169,7 @@ private:
 
 	BBox GetBoundsFromSurface(const LevelMeshSurface& surface) const;
 
-	int AddSurfaceToTile(const DoomSurfaceInfo& info, const LevelMeshSurface& surf, uint16_t sampleDimension, bool alwaysUpdate);
+	int AddSurfaceToTile(const DoomSurfaceInfo& info, const LevelMeshSurface& surf, uint16_t sampleDimension, uint8_t alwaysUpdate);
 	int GetSampleDimension(uint16_t sampleDimension);
 
 	void CreatePortals(FLevelLocals& doomMap);

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -14,6 +14,7 @@
 
 EXTERN_CVAR(Bool, lm_always_update);
 EXTERN_CVAR(Int, lm_max_updates);
+EXTERN_CVAR(Bool, lm_dynamic);
 
 enum EDrawMode
 {
@@ -239,7 +240,7 @@ public:
 		}
 
 		LightmapTile* tile = &Level->levelMesh->Lightmap.Tiles[tileIndex];
-		if (lm_always_update || tile->AlwaysUpdate)
+		if (lm_always_update || tile->AlwaysUpdate == 2 || (tile->AlwaysUpdate == 1 && lm_dynamic))
 		{
 			tile->NeedsUpdate = true;
 		}

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -52,7 +52,7 @@ class ActorTraceStaticLight
 public:
 	ActorTraceStaticLight(AActor* actor) : Actor(actor)
 	{
-		if (Actor && (Actor->Pos() != Actor->StaticLightsTraceCache.Pos || (Actor->Sector && (Actor->Sector->Flags & SECF_LM_DYNAMIC))))
+		if (Actor && (Actor->Pos() != Actor->StaticLightsTraceCache.Pos || (Actor->Sector && (Actor->Sector->Flags & SECF_LM_DYNAMIC) && lm_dynamic)))
 		{
 			Actor->StaticLightsTraceCache.Pos = Actor->Pos();
 			Actor->StaticLightsTraceCache.Bits = 0;


### PR DESCRIPTION
Allows disabling of this feature via `lm_dynamic` for lower end hardware so they can continue to make use of the lightmaps without having to outright disable them. This may provide some lighting issues here and there but ultimately beats having to disable the lightmap in its entirety should someone make only sparse use of the feature in their map.