### PR TITLE
improve SDL mouse handling in menus

### DIFF
--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -180,12 +180,12 @@ void I_SetMouseCapture()
 {
 	// Clear out any mouse movement.
 	SDL_GetRelativeMouseState (NULL, NULL);
-	SDL_SetRelativeMouseMode (SDL_TRUE);
+	SDL_CaptureMouse (SDL_TRUE);
 }
 
 void I_ReleaseMouseCapture()
 {
-	SDL_SetRelativeMouseMode (SDL_FALSE);
+	SDL_CaptureMouse (SDL_FALSE);
 }
 
 static void MouseRead ()
@@ -215,10 +215,12 @@ static void I_CheckNativeMouse ()
 	{
 		NativeMouse = wantNative;
 		SDL_ShowCursor (wantNative);
-		if (wantNative)
-			I_ReleaseMouseCapture ();
-		else
-			I_SetMouseCapture ();
+		if (wantNative) {
+			SDL_SetRelativeMouseMode (SDL_FALSE);
+		} else {
+			SDL_GetRelativeMouseState (NULL, NULL);
+			SDL_SetRelativeMouseMode (SDL_TRUE);
+		}
 	}
 }
 


### PR DESCRIPTION
previously mouse handling was a bit wonky on linux because clicking would make the cursor disappear (since it got put into relative mode for some reason), which i was able to ignore but for some reason now on my system clicking makes the mouse cursor jump to weird places on the screen.

so this makes the mouse handling work more like the windows backend, doesn't seem to break anything from my testing