### PR TITLE
fix a compile error for me caused by a warning being promoted to a security error

### DIFF
--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -1072,7 +1072,7 @@ void I_NetError(const char* error)
 {
 	doomcom.numnodes = 0;
 	StartWindow->NetClose();
-	I_FatalError(error);
+	I_FatalError("%s", error);
 }
 
 // todo: later these must be dispatched by the main menu, not the start screen.


### PR DESCRIPTION
not really sure why this happens but this is making vkdoom fail to compile for me, it's complaining about a security issue that can happen by using a string instead of a formatting literal - seems easier to just take its suggestion than figure out what part of the cmake or my config is promoting this from a warning to an error (maybe a new clang version?)