### PR TITLE
add camera-facing midtexture shadows to dynamic lights, off by default due to fps hit

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_cvars.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.cpp
@@ -182,3 +182,5 @@ int get_gl_spritelight()
 
 CVARD(Bool, gl_fakemodellight, true, CVAR_GLOBALCONFIG | CVAR_ARCHIVE, "adds a fake sunlight on models to improve contrast")
 CVARD(Float, gl_fakemodellightintensity, 0.05, CVAR_GLOBALCONFIG | CVAR_ARCHIVE, "fake sunlight intensity (brightness)")
+
+CVARD(Bool, gl_precise_midtextures_trace, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE, "trace midtextures facing towards camera, only needed for maps that don't use midtextures 'evenly', roughly doubles the cost of ray-traced lights")

--- a/src/common/rendering/hwrenderer/data/hw_cvars.h
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.h
@@ -67,3 +67,4 @@ int get_gl_spritelight();
 
 EXTERN_CVAR(Bool, gl_fakemodellight)
 EXTERN_CVAR(Float, gl_fakemodellightintensity)
+EXTERN_CVAR(Bool, gl_precise_midtextures_trace)

--- a/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
@@ -40,6 +40,8 @@ struct HWViewpointUniforms
 
 	int mLightTilesWidth = 0;
 
+	FVector3 mCameraNormal;
+
 	void CalcDependencies()
 	{
 		mNormalViewMatrix.computeNormalMatrix(mViewMatrix);

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -391,6 +391,7 @@ void VkShaderManager::BuildDefinesBlock(FString &definesBlock, const char *defin
 
 	if (key.UseRaytrace) definesBlock << "#define USE_RAYTRACE\n";
 	if (key.UseRaytracePrecise) definesBlock << "#define USE_RAYTRACE_PRECISE\n";
+	if (key.PreciseMidtextureTrace) definesBlock << "#define PRECISE_MIDTEXTURES\n";
 
 	definesBlock << "#define SHADOWMAP_FILTER ";
 	definesBlock << std::to_string(key.ShadowmapFilter).c_str();

--- a/src/common/rendering/vulkan/shaders/vk_shader.h
+++ b/src/common/rendering/vulkan/shaders/vk_shader.h
@@ -111,7 +111,8 @@ public:
 			uint64_t ShadeVertex : 1; // SHADE_VERTEX
 			uint64_t LightNoNormals : 1; // LIGHT_NONORMALS
 			uint64_t UseSpriteCenter : 1; // USE_SPRITE_CENTER
-			uint64_t Unused : 27;
+			uint64_t PreciseMidtextureTrace : 1; // PRECISE_MIDTEXTURES
+			uint64_t Unused : 26;
 		};
 		uint64_t AsQWORD = 0;
 	};

--- a/src/common/rendering/vulkan/vk_renderstate.cpp
+++ b/src/common/rendering/vulkan/vk_renderstate.cpp
@@ -336,6 +336,7 @@ void VkRenderState::ApplyRenderPass(int dt)
 	pipelineKey.ShaderKey.UseShadowmap = gl_light_shadows == 1;
 	pipelineKey.ShaderKey.UseRaytrace = gl_light_shadows >= 2;
 	pipelineKey.ShaderKey.UseRaytracePrecise = gl_light_shadows >= 3;
+	pipelineKey.ShaderKey.PreciseMidtextureTrace = gl_precise_midtextures_trace;
 	pipelineKey.ShaderKey.ShadowmapFilter = std::clamp(int(gl_light_shadow_filter), 0, 15);
 
 	pipelineKey.ShaderKey.GBufferPass = mRenderTarget.DrawBuffers > 1;
@@ -1091,6 +1092,7 @@ void VkRenderState::ApplyLevelMeshPipeline(VulkanCommandBuffer* cmdbuffer, VkPip
 	pipelineKey.ShaderKey.UseShadowmap = gl_light_shadows == 1;
 	pipelineKey.ShaderKey.UseRaytrace = gl_light_shadows >= 2;
 	pipelineKey.ShaderKey.UseRaytracePrecise = gl_light_shadows >= 3;
+	pipelineKey.ShaderKey.PreciseMidtextureTrace = gl_precise_midtextures_trace;
 	pipelineKey.ShaderKey.ShadowmapFilter = std::clamp(int(gl_light_shadow_filter), 0, 15);
 
 	pipelineKey.ShaderKey.GBufferPass = mRenderTarget.DrawBuffers > 1;

--- a/src/common/utility/vectors.h
+++ b/src/common/utility/vectors.h
@@ -710,6 +710,13 @@ struct TVector3
 		*this = *this ^ other;
 		return *this;
 	}
+
+
+	// returns a version with swapped Z/Y
+	constexpr const TVector3 ToXZY() const
+	{
+		return {X, Z, Y};
+	}
 };
 
 template<class vec_t>

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -356,6 +356,10 @@ void HWDrawInfo::SetViewMatrix(const FRotator &angles, float vx, float vy, float
 	VPUniforms.mViewMatrix.rotate(angles.Yaw.Degrees(), 0.0f, mult, 0.0f);
 	VPUniforms.mViewMatrix.translate(vx * mult, -vz * planemult, -vy);
 	VPUniforms.mViewMatrix.scale(-mult, planemult, 1);
+
+	FRotator unfuckedAngles(angles.Pitch, FAngle::fromDeg(90 - angles.Yaw.Degrees()), angles.Roll);
+
+	VPUniforms.mCameraNormal = FVector3(unfuckedAngles).ToXZY();
 }
 
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1070,6 +1070,7 @@ OptionMenu "LightOptions" protected
 	Option "$GLLIGHTMNU_LIGHTSHADOWS",			gl_light_shadows,		"ShadowMode"
 	Option "$GLLIGHTMNU_LIGHTSHADOWFILTER", 	gl_light_shadow_filter,	"ShadowFilter"
 	Option "$GLLIGHTMNU_LIGHTSHADOWMAPQUALITY", gl_shadowmap_quality,	"ShadowMapQuality"
+	Option "$GLLIGHTMNU_PRECISEMIDTEXTRACE",	gl_precise_midtextures_trace,	"YesNo"
 	StaticText " "
 	Option "$GLPREFMNU_SWLMBANDED",				gl_bandedswlight,				"OnOff"
 	Option "$GLPREFMNU_FOGFORCEFULLBRIGHT",		gl_brightfog,					"YesNo"

--- a/wadsrc/static/shaders/lightmap/polyfill_rayquery.glsl
+++ b/wadsrc/static/shaders/lightmap/polyfill_rayquery.glsl
@@ -43,6 +43,41 @@ TraceResult TraceFirstHit(vec3 origin, float tmin, vec3 dir, float tmax)
 	return result;
 }
 
+TraceResult TraceFirstHitReverse(vec3 origin, float tmin, vec3 dir, float tmax)
+{
+	TraceResult result;
+
+	rayQueryEXT rayQuery;
+	rayQueryInitializeEXT(rayQuery, acc, gl_RayFlagsCullFrontFacingTrianglesEXT, 0xFF, origin, tmin, dir, tmax);
+
+	while(rayQueryProceedEXT(rayQuery))
+	{
+		if (rayQueryGetIntersectionTypeEXT(rayQuery, false) == gl_RayQueryCommittedIntersectionTriangleEXT)
+		{
+			rayQueryConfirmIntersectionEXT(rayQuery);
+		}
+	}
+
+	if (rayQueryGetIntersectionTypeEXT(rayQuery, true) == gl_RayQueryCommittedIntersectionTriangleEXT)
+	{
+		result.t = rayQueryGetIntersectionTEXT(rayQuery, true);
+
+		result.primitiveWeights.xy = rayQueryGetIntersectionBarycentricsEXT(rayQuery, true);
+		result.primitiveWeights.z = 1.0 - result.primitiveWeights.x - result.primitiveWeights.y;
+
+		result.primitiveIndex =
+			rayQueryGetIntersectionInstanceCustomIndexEXT(rayQuery, true) +
+			rayQueryGetIntersectionPrimitiveIndexEXT(rayQuery, true);
+	}
+	else
+	{
+		result.t = tmax;
+		result.primitiveIndex = -1;
+	}
+
+	return result;
+}
+
 bool TraceAnyHit(vec3 origin, float tmin, vec3 dir, float tmax)
 {
 	rayQueryEXT rayQuery;
@@ -275,5 +310,8 @@ TraceResult TraceFirstHit(vec3 origin, float tmin, vec3 dir, float tmax)
 	result.primitiveIndex = -1;
 	return result;
 }
+
+//no nice tracing for you sorry
+#define TraceFirstHitReverse TraceFirstHit
 
 #endif

--- a/wadsrc/static/shaders/scene/binding_rsbuffers.glsl
+++ b/wadsrc/static/shaders/scene/binding_rsbuffers.glsl
@@ -18,6 +18,8 @@ layout(set = 1, binding = 0, std140) uniform readonly ViewpointUBO
 	float uClipHeightDirection;
 
 	int uLightTilesWidth;	// Levelmesh light tiles
+
+	vec3 uCameraNormal;
 };
 
 layout(set = 1, binding = 1, std140) uniform readonly MatricesUBO

--- a/wadsrc/static/shaders/scene/light_trace.glsl
+++ b/wadsrc/static/shaders/scene/light_trace.glsl
@@ -33,9 +33,6 @@ float TraceDynLightRay(vec3 origin, float tmin, vec3 direction, float dist)
 					bool frontFacing = TraceHitIsFacing(origin + direction * frontResult.t, frontSurface);
 					bool backFacing = TraceHitIsFacing(origin + direction * backResult.t, backSurface);
 
-					//bool frontFacing = dot(frontSurface.Normal, uCameraNormal) > 0;
-					//bool backFacing = dot(backSurface.Normal, uCameraNormal) > 0;
-
 					if(frontFacing && frontFacing == backFacing)
 					{
 						skip = false;
@@ -67,13 +64,13 @@ float TraceDynLightRay(vec3 origin, float tmin, vec3 direction, float dist)
 				{
 					result = frontResult;
 					surface = GetSurface(frontResult.primitiveIndex);
-					skip = TraceHitIsFacing(origin + direction * result.t, surface);//dot(surface.Normal, uCameraNormal) < 0;
+					skip = TraceHitIsFacing(origin + direction * result.t, surface);
 				}
 				else if(backResult.primitiveIndex != -1)
 				{
 					result = backResult;
 					surface = GetSurface(backResult.primitiveIndex);
-					skip = TraceHitIsFacing(origin + direction * result.t, surface);//dot(surface.Normal, uCameraNormal) < 0;
+					skip = TraceHitIsFacing(origin + direction * result.t, surface);
 				}
 				else
 				{


### PR DESCRIPTION
it needs to trace twice and run logic to find the closest hit (if any) that's facing the camera, so it's off by default