### PR TITLE
Lightprobe WIP part 2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -888,6 +888,7 @@ set (PCH_SOURCES
 	rendering/hwrenderer/hw_vertexbuilder.cpp
 	rendering/hwrenderer/doom_aabbtree.cpp
 	rendering/hwrenderer/doom_levelmesh.cpp
+	rendering/hwrenderer/doom_lightprobes.cpp
 	rendering/hwrenderer/hw_models.cpp
 	rendering/hwrenderer/hw_precache.cpp
 	rendering/hwrenderer/scene/hw_lighting.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1122,6 +1122,7 @@ set (PCH_SOURCES
 	common/rendering/hwrenderer/data/hw_collision.cpp
 	common/rendering/hwrenderer/data/hw_levelmesh.cpp
 	common/rendering/hwrenderer/data/hw_meshbuilder.cpp
+	common/rendering/hwrenderer/data/hw_lightprobe.cpp
 	common/rendering/hwrenderer/postprocessing/hw_postprocessshader.cpp
 	common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
 	common/rendering/hwrenderer/postprocessing/hw_postprocess_cvars.cpp

--- a/src/common/rendering/hwrenderer/data/hw_lightprobe.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_lightprobe.cpp
@@ -1,0 +1,52 @@
+#include "hw_lightprobe.h"
+
+void LightProbeIncrementalBuilder::Step(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv)
+{
+	if (lastIndex >= probes.size())
+	{
+		lastIndex = 0;
+
+		if (!probes.size())
+		{
+			return;
+		}
+	}
+
+	TArray<uint16_t> irradianceMap;
+	TArray<uint16_t> prefilterMap;
+
+	renderScene(probes[lastIndex++], irradianceMap, prefilterMap);
+	++collected;
+
+	this->irradianceMaps.Append(irradianceMap);
+	this->prefilterMaps.Append(prefilterMap);
+
+	if (lastIndex >= probes.size())
+	{
+		if (collected == probes.size())
+		{
+			uploadEnv(std::move(this->irradianceMaps), std::move(this->prefilterMaps));
+		}
+		this->irradianceMaps.Clear();
+		this->prefilterMaps.Clear();
+		collected = 0;
+	}
+}
+
+void LightProbeIncrementalBuilder::Full(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv)
+{
+	if (lastIndex >= probes.size())
+	{
+		lastIndex = 0;
+
+		if (!probes.size())
+		{
+			return;
+		}
+	}
+
+	while (lastIndex < probes.size())
+	{
+		Step(probes, renderScene, uploadEnv);
+	}
+}

--- a/src/common/rendering/hwrenderer/data/hw_lightprobe.h
+++ b/src/common/rendering/hwrenderer/data/hw_lightprobe.h
@@ -16,16 +16,25 @@ struct LightProbeTarget
 class LightProbeIncrementalBuilder
 {
 	int lastIndex = 0;
+	int collected = 0;
 
-	int collected;
-	
+	int cubemapsAllocated = 0;
+
 	TArray<uint16_t> irradianceMaps;
 	TArray<uint16_t> prefilterMaps;
 
+	size_t irradianceBytes;
+	size_t prefilterBytes;
 public:
+	LightProbeIncrementalBuilder(size_t irradianceTexels, size_t prefilterTexels, size_t irradianceChannels, size_t prefilterChannels) :
+		irradianceBytes(irradianceTexels * irradianceChannels),
+		prefilterBytes(prefilterTexels * prefilterChannels)
+	{
+	}
 
-	void Step(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv);
-	void Full(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv);
+	void Step(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArrayView<uint16_t>&, TArrayView<uint16_t>&)> renderScene, std::function<void(const TArray<uint16_t>&, const TArray<uint16_t>&)> uploadEnv);
+	void Full(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArrayView<uint16_t>&, TArrayView<uint16_t>&)> renderScene, std::function<void(const TArray<uint16_t>&, const TArray<uint16_t>&)> uploadEnv);
 
 	auto GetStep() const { return lastIndex; }
+	auto GetBufferSize() const { return irradianceMaps.size() && prefilterMaps.size(); }
 };

--- a/src/common/rendering/hwrenderer/data/hw_lightprobe.h
+++ b/src/common/rendering/hwrenderer/data/hw_lightprobe.h
@@ -12,3 +12,20 @@ struct LightProbeTarget
 {
 	int index = 0; // parameter for renderstate.SetLightProbe
 };
+
+class LightProbeIncrementalBuilder
+{
+	int lastIndex = 0;
+
+	int collected;
+	
+	TArray<uint16_t> irradianceMaps;
+	TArray<uint16_t> prefilterMaps;
+
+public:
+
+	void Step(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv);
+	void Full(const TArray<LightProbe>& probes, std::function<void(const LightProbe&, TArray<uint16_t>&, TArray<uint16_t>&)> renderScene, std::function<void(TArray<uint16_t>&&, TArray<uint16_t>&&)> uploadEnv);
+
+	auto GetStep() const { return lastIndex; }
+};

--- a/src/common/rendering/hwrenderer/data/hw_lightprobe.h
+++ b/src/common/rendering/hwrenderer/data/hw_lightprobe.h
@@ -7,3 +7,8 @@ struct LightProbe
 	FVector3 position;
 	int index = 0;
 };
+
+struct LightProbeTarget
+{
+	int index = 0; // parameter for renderstate.SetLightProbe
+};

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -221,7 +221,8 @@ public:
 	// Get the array index for the material in the textures array accessible from shaders
 	virtual int GetBindlessTextureIndex(FMaterial* material, int clampmode, int translation) { return -1; }
 
-	virtual void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc) {}
+	virtual void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap) {}
+	virtual void UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps) {}
 
 	// Screen wiping
 	virtual FTexture *WipeStartScreen();

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -221,8 +221,8 @@ public:
 	// Get the array index for the material in the textures array accessible from shaders
 	virtual int GetBindlessTextureIndex(FMaterial* material, int clampmode, int translation) { return -1; }
 
-	virtual void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap) {}
-	virtual void UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps) {}
+	virtual void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArrayView<uint16_t>& irradianceMap, TArrayView<uint16_t>& prefilterMap) {}
+	virtual void UploadEnvironmentMaps(int cubemapCount, const TArray<uint16_t>& irradianceMaps, const TArray<uint16_t>& prefilterMaps) {}
 
 	// Screen wiping
 	virtual FTexture *WipeStartScreen();

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -132,7 +132,7 @@ public:
 
 	// Lightprobes
 	constexpr static const int irrandiaceMapTexelCount = 32 * 32 * 6;
-	constexpr static const int prefilterMapLevelsSize = 5;
+	constexpr static const int prefilterMapLevelsSize = 128 * 128 + 64 * 64 + 32 * 32 + 16 * 16 + 8 * 8;
 	constexpr static const int prefilterMapTexelCount = prefilterMapLevelsSize * 6;
 
 	constexpr static const int irradianceMapChannelCount = 3;

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -130,6 +130,14 @@ public:
 	int mPipelineNbr = 1;						// Number of HW buffers to pipeline
 	int mPipelineType = 0;
 
+	// Lightprobes
+	constexpr static const int irrandiaceMapTexelCount = 32 * 32 * 6;
+	constexpr static const int prefilterMapLevelsSize = 5;
+	constexpr static const int prefilterMapTexelCount = prefilterMapLevelsSize * 6;
+
+	constexpr static const int irradianceMapChannelCount = 3;
+	constexpr static const int prefilterMapChannelCount = 3;
+
 public:
 	DFrameBuffer (int width=1, int height=1);
 	virtual ~DFrameBuffer();

--- a/src/common/rendering/vulkan/textures/vk_texture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_texture.cpp
@@ -279,7 +279,7 @@ void VkTextureManager::CreatePrefiltermap()
 	CreatePrefiltermap(size, 6, std::move(data));
 }
 
-void VkTextureManager::CreateIrradiancemap(int size, int count, TArray<uint16_t>&& newPixelData)
+void VkTextureManager::CreateIrradiancemap(int size, int count, const TArray<uint16_t>& newPixelData)
 {
 	if (Irradiancemap.Size == size && Irradiancemap.Count == count && newPixelData.Size() == 0)
 		return;
@@ -346,8 +346,6 @@ void VkTextureManager::CreateIrradiancemap(int size, int count, TArray<uint16_t>
 		cmdbuffer->copyBufferToImage(stagingBuffer->buffer, Irradiancemap.Image.Image->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
 		fb->GetCommands()->TransferDeleteList->Add(std::move(stagingBuffer));
-
-		newPixelData.Clear();
 	}
 
 	VkImageTransition()
@@ -355,7 +353,7 @@ void VkTextureManager::CreateIrradiancemap(int size, int count, TArray<uint16_t>
 		.Execute(cmdbuffer);
 }
 
-void VkTextureManager::CreatePrefiltermap(int size, int count, TArray<uint16_t>&& newPixelData)
+void VkTextureManager::CreatePrefiltermap(int size, int count, const TArray<uint16_t>& newPixelData)
 {
 	if (Prefiltermap.Size == size && Prefiltermap.Count == count && newPixelData.Size() == 0)
 		return;
@@ -443,8 +441,6 @@ void VkTextureManager::CreatePrefiltermap(int size, int count, TArray<uint16_t>&
 		}
 
 		fb->GetCommands()->TransferDeleteList->Add(std::move(stagingBuffer));
-
-		newPixelData.Clear();
 	}
 
 	VkImageTransition()

--- a/src/common/rendering/vulkan/textures/vk_texture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_texture.cpp
@@ -420,7 +420,7 @@ void VkTextureManager::CreatePrefiltermap(int size, int count, TArray<uint16_t>&
 			.Execute(cmdbuffer);
 
 		int offset = 0;
-		for (int i = 0; i < 6; ++i)
+		for (int i = 0; i < count; ++i)
 		{
 			for (int level = 0; level < miplevels; level++)
 			{

--- a/src/common/rendering/vulkan/textures/vk_texture.h
+++ b/src/common/rendering/vulkan/textures/vk_texture.h
@@ -24,8 +24,8 @@ public:
 	void BeginFrame();
 
 	void CreateLightmap(int size, int count, TArray<uint16_t>&& data);
-	void CreateIrradiancemap(int size, int count, TArray<uint16_t>&& data);
-	void CreatePrefiltermap(int size, int count, TArray<uint16_t>&& data);
+	void CreateIrradiancemap(int size, int count, const TArray<uint16_t>& data);
+	void CreatePrefiltermap(int size, int count, const TArray<uint16_t>& data);
 	void DownloadLightmap(int arrayIndex, uint16_t* buffer);
 
 	VkTextureImage* GetTexture(const PPTextureType& type, PPTexture* tex);

--- a/src/common/rendering/vulkan/vk_lightprober.cpp
+++ b/src/common/rendering/vulkan/vk_lightprober.cpp
@@ -256,8 +256,15 @@ void VkLightprober::CreateIrradianceMap()
 	}
 }
 
-TArray<uint16_t> VkLightprober::GenerateIrradianceMap()
+bool VkLightprober::GenerateIrradianceMap(TArrayView<uint16_t>& databuffer)
 {
+	const int texelCount = irrandiaceMapTexelCount;
+
+	if (databuffer.Size() < texelCount)
+	{
+		return false;
+	}
+
 	auto staging = BufferBuilder()
 		.Size(32 * 32 * 8 * 6)
 		.Usage(VK_BUFFER_USAGE_TRANSFER_DST_BIT, VMA_MEMORY_USAGE_GPU_TO_CPU)
@@ -334,9 +341,7 @@ TArray<uint16_t> VkLightprober::GenerateIrradianceMap()
 	fb->GetCommands()->WaitForCommands(false);
 
 	// Copy while dropping the alpha channel
-	int texelCount = 32 * 32 * 6;
-	TArray<uint16_t> databuffer(texelCount * 3, true);
-	auto dst = databuffer.data();
+	auto dst = databuffer.Data();
 	auto src = (uint16_t*)staging->Map(0, texelCount * 8);
 	for (int i = 0; i < texelCount; i++)
 	{
@@ -346,7 +351,7 @@ TArray<uint16_t> VkLightprober::GenerateIrradianceMap()
 		src++;
 	}
 	staging->Unmap();
-	return databuffer;
+	return true;
 }
 
 void VkLightprober::CreatePrefilterMap()
@@ -398,8 +403,15 @@ void VkLightprober::CreatePrefilterMap()
 	}
 }
 
-TArray<uint16_t> VkLightprober::GeneratePrefilterMap()
+bool VkLightprober::GeneratePrefilterMap(TArrayView<uint16_t>& databuffer)
 {
+	const int texelCount = prefilterMapTexelCount;
+
+	if (databuffer.Size() < texelCount)
+	{
+		return false;
+	}
+
 	auto staging = BufferBuilder()
 		.Size(prefilterMap.levelsSize * 6 * 8)
 		.Usage(VK_BUFFER_USAGE_TRANSFER_DST_BIT, VMA_MEMORY_USAGE_GPU_TO_CPU)
@@ -484,9 +496,7 @@ TArray<uint16_t> VkLightprober::GeneratePrefilterMap()
 	fb->GetCommands()->WaitForCommands(false);
 
 	// Copy while dropping the alpha channel
-	int texelCount = prefilterMap.levelsSize * 6;
-	TArray<uint16_t> databuffer(texelCount * 3, true);
-	auto dst = databuffer.data();
+	auto dst = databuffer.Data();
 	auto src = (uint16_t*)staging->Map(0, texelCount * 8);
 	for (int i = 0; i < texelCount; i++)
 	{
@@ -496,7 +506,7 @@ TArray<uint16_t> VkLightprober::GeneratePrefilterMap()
 		src++;
 	}
 	staging->Unmap();
-	return databuffer;
+	return true;
 }
 
 std::unique_ptr<VulkanShader> VkLightprober::CompileShader(const std::string& name, const std::string& filename, const char* debugName)

--- a/src/common/rendering/vulkan/vk_lightprober.cpp
+++ b/src/common/rendering/vulkan/vk_lightprober.cpp
@@ -258,7 +258,7 @@ void VkLightprober::CreateIrradianceMap()
 
 bool VkLightprober::GenerateIrradianceMap(TArrayView<uint16_t>& databuffer)
 {
-	const int texelCount = irrandiaceMapTexelCount;
+	const int texelCount = DFrameBuffer::irrandiaceMapTexelCount;
 
 	if (databuffer.Size() < texelCount)
 	{
@@ -405,7 +405,7 @@ void VkLightprober::CreatePrefilterMap()
 
 bool VkLightprober::GeneratePrefilterMap(TArrayView<uint16_t>& databuffer)
 {
-	const int texelCount = prefilterMapTexelCount;
+	const int texelCount = DFrameBuffer::prefilterMapTexelCount;
 
 	if (databuffer.Size() < texelCount)
 	{

--- a/src/common/rendering/vulkan/vk_lightprober.h
+++ b/src/common/rendering/vulkan/vk_lightprober.h
@@ -93,8 +93,8 @@ private:
 	{
 		enum
 		{
-			maxlevels = DFrameBuffer::prefilterMapLevelsSize,
-			levelsSize = 128 * 128 + 64 * 64 + 32 * 32 + 16 * 16 + 8 * 8
+			maxlevels = 5,
+			levelsSize = DFrameBuffer::prefilterMapLevelsSize
 		};
 		std::unique_ptr<VulkanShader> shader;
 		std::unique_ptr<VulkanDescriptorSetLayout> descriptorSetLayout;

--- a/src/common/rendering/vulkan/vk_lightprober.h
+++ b/src/common/rendering/vulkan/vk_lightprober.h
@@ -35,8 +35,8 @@ public:
 	~VkLightprober();
 
 	void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc);
-	TArray<uint16_t> GenerateIrradianceMap();
-	TArray<uint16_t> GeneratePrefilterMap();
+	bool GenerateIrradianceMap(TArrayView<uint16_t>& databuffer);
+	bool GeneratePrefilterMap(TArrayView<uint16_t>& databuffer);
 
 private:
 	void CreateBrdfLutResources();
@@ -89,7 +89,7 @@ private:
 		std::unique_ptr<VulkanImageView> views[6];
 	} irradianceMap;
 
-	struct
+	struct PrefilterMap
 	{
 		enum
 		{
@@ -108,4 +108,12 @@ private:
 	} prefilterMap;
 
 	VulkanRenderDevice* fb = nullptr;
+
+public:
+	// Used to pass buffer sizes
+	constexpr static const int irrandiaceMapTexelCount = 32 * 32 * 6;
+	constexpr static const int prefilterMapTexelCount = PrefilterMap::levelsSize * 6;
+
+	constexpr static const int irradianceMapChannelCount = 3;
+	constexpr static const int prefilterMapChannelCount = 3;
 };

--- a/src/common/rendering/vulkan/vk_lightprober.h
+++ b/src/common/rendering/vulkan/vk_lightprober.h
@@ -93,7 +93,7 @@ private:
 	{
 		enum
 		{
-			maxlevels = 5,
+			maxlevels = DFrameBuffer::prefilterMapLevelsSize,
 			levelsSize = 128 * 128 + 64 * 64 + 32 * 32 + 16 * 16 + 8 * 8
 		};
 		std::unique_ptr<VulkanShader> shader;
@@ -108,12 +108,4 @@ private:
 	} prefilterMap;
 
 	VulkanRenderDevice* fb = nullptr;
-
-public:
-	// Used to pass buffer sizes
-	constexpr static const int irrandiaceMapTexelCount = 32 * 32 * 6;
-	constexpr static const int prefilterMapTexelCount = PrefilterMap::levelsSize * 6;
-
-	constexpr static const int irradianceMapChannelCount = 3;
-	constexpr static const int prefilterMapChannelCount = 3;
 };

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -321,18 +321,17 @@ void VulkanRenderDevice::RenderTextureView(FCanvasTexture* tex, std::function<vo
 	tex->SetUpdated(true);
 }
 
-void VulkanRenderDevice::RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap)
+void VulkanRenderDevice::RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArrayView<uint16_t>& irradianceMap, TArrayView<uint16_t>& prefilterMap)
 {
 	mLightprober->RenderEnvironmentMap(std::move(renderFunc));
-	irradianceMap = mLightprober->GenerateIrradianceMap();
-	prefilterMap = mLightprober->GeneratePrefilterMap();
-	
+	mLightprober->GenerateIrradianceMap(irradianceMap);
+	mLightprober->GeneratePrefilterMap(prefilterMap);
 }
 
-void VulkanRenderDevice::UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps)
+void VulkanRenderDevice::UploadEnvironmentMaps(int cubemapCount, const TArray<uint16_t>& irradianceMaps, const TArray<uint16_t>& prefilterMaps)
 {
-	mTextureManager->CreateIrradiancemap(32, 6 * cubemapCount, std::move(irradianceMaps));
-	mTextureManager->CreatePrefiltermap(128, 6 * cubemapCount, std::move(prefilterMaps));
+	mTextureManager->CreateIrradiancemap(32, 6 * cubemapCount, irradianceMaps);
+	mTextureManager->CreatePrefiltermap(128, 6 * cubemapCount, prefilterMaps);
 }
 
 void VulkanRenderDevice::PostProcessScene(bool swscene, int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D)

--- a/src/common/rendering/vulkan/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/vk_renderdevice.cpp
@@ -321,13 +321,18 @@ void VulkanRenderDevice::RenderTextureView(FCanvasTexture* tex, std::function<vo
 	tex->SetUpdated(true);
 }
 
-void VulkanRenderDevice::RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc)
+void VulkanRenderDevice::RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap)
 {
 	mLightprober->RenderEnvironmentMap(std::move(renderFunc));
-	TArray<uint16_t> irradianceMap = mLightprober->GenerateIrradianceMap();
-	TArray<uint16_t> prefilterMap = mLightprober->GeneratePrefilterMap();
-	mTextureManager->CreateIrradiancemap(32, 6, std::move(irradianceMap));
-	mTextureManager->CreatePrefiltermap(128, 6, std::move(prefilterMap));
+	irradianceMap = mLightprober->GenerateIrradianceMap();
+	prefilterMap = mLightprober->GeneratePrefilterMap();
+	
+}
+
+void VulkanRenderDevice::UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps)
+{
+	mTextureManager->CreateIrradiancemap(32, 6 * cubemapCount, std::move(irradianceMaps));
+	mTextureManager->CreatePrefiltermap(128, 6 * cubemapCount, std::move(prefilterMaps));
 }
 
 void VulkanRenderDevice::PostProcessScene(bool swscene, int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D)

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -104,8 +104,8 @@ public:
 
 private:
 	void RenderTextureView(FCanvasTexture* tex, std::function<void(IntRect &)> renderFunc) override;
-	void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap) override;
-	void UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps) override;
+	void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArrayView<uint16_t>& irradianceMap, TArrayView<uint16_t>& prefilterMap) override;
+	void UploadEnvironmentMaps(int cubemapCount, const TArray<uint16_t>& irradianceMaps, const TArray<uint16_t>& prefilterMaps) override;
 	void PrintStartupLog();
 	void CopyScreenToBuffer(int w, int h, uint8_t *data) override;
 

--- a/src/common/rendering/vulkan/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/vk_renderdevice.h
@@ -104,7 +104,8 @@ public:
 
 private:
 	void RenderTextureView(FCanvasTexture* tex, std::function<void(IntRect &)> renderFunc) override;
-	void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc) override;
+	void RenderEnvironmentMap(std::function<void(IntRect& bounds, int side)> renderFunc, TArray<uint16_t>& irradianceMap, TArray<uint16_t>& prefilterMap) override;
+	void UploadEnvironmentMaps(int cubemapCount, TArray<uint16_t>&& irradianceMaps, TArray<uint16_t>&& prefilterMaps) override;
 	void PrintStartupLog();
 	void CopyScreenToBuffer(int w, int h, uint8_t *data) override;
 

--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -44,6 +44,7 @@
 
 #include "hwrenderer/data/buffers.h"
 #include "hwrenderer/data/hw_levelmesh.h"
+#include "hwrenderer/data/hw_lightprobe.h"
 
 // Some more or less basic data types
 // we depend on.
@@ -785,6 +786,8 @@ struct sector_t
 	int	healthceilinggroup;
 	int	health3dgroup;
 
+	LightProbeTarget lightProbe; // TODO split individual flats in the sector including 3d floors
+
 	// Member functions
 
 private:
@@ -1295,6 +1298,7 @@ struct side_t
 	int			UDMFIndex;		// needed to access custom UDMF fields which are stored in loading order.
 	FLightNode * lighthead;		// all dynamic lights that may affect this wall
 	TArrayView<int> LightmapTiles; // all lightmap tiles belonging to this sidedef
+	LightProbeTarget lightProbe; // TODO use different probe per each part (and 3D floors)
 	seg_t **segs;	// all segs belonging to this sidedef in ascending order. Used for precise rendering
 	int numsegs;
 	int sidenum;

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -881,6 +881,9 @@ xx(light_dontlightactors)
 xx(light_dontlightmap)
 xx(light_shadowminquality)
 
+// Light probe
+xx(LightProbe)
+
 xx(skew_bottom_type)
 xx(skew_middle_type)
 xx(skew_top_type)

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -379,6 +379,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	if (levelMesh) delete levelMesh;
 	aabbTree = nullptr;
 	levelMesh = nullptr;
+	lightProbes.Clear();
 	if (screen)
 		screen->SetLevelMesh(nullptr);
 	if (screen && screen->mShadowMap)

--- a/src/rendering/hwrenderer/doom_lightprobes.cpp
+++ b/src/rendering/hwrenderer/doom_lightprobes.cpp
@@ -1,0 +1,102 @@
+#include "c_dispatch.h"
+#include "g_levellocals.h"
+
+static int FindClosestProbe(FVector3 pos)
+{
+	float bestDist = std::numeric_limits<float>::max();
+	int best = 0;
+
+	for (int i = 0, size = level.lightProbes.size(); i < size; ++i)
+	{
+		const auto& probe = level.lightProbes[i];
+
+		const auto probeDist = (probe.position - pos).LengthSquared();
+
+		if (probeDist < bestDist)
+		{
+			best = i;
+			bestDist = probeDist;
+		}
+	}
+
+	return best;
+}
+
+static void RecalculateLightProbeTargets()
+{
+	for (int i = 0, size = level.sectors.size(); i < size; ++i)
+	{
+		auto& sector = level.sectors[i];
+		const auto origin = FVector3(sector.centerspot.X, sector.centerspot.Y, float(sector.floorplane.ZatPoint(sector.centerspot) + 64.0));
+
+		sector.lightProbe.index = FindClosestProbe(origin);
+	}
+
+	for (int i = 0, size = level.sides.size(); i < size; ++i)
+	{
+		auto& side = level.sides[i];
+
+		const auto sector = side.sector;
+
+		if (!sector) // better safe than sorry
+		{
+			continue;
+		}
+
+		const auto xy = side.linedef->v1->fPos() + side.linedef->delta * 0.5;
+		const auto origin = FVector3(xy.X, xy.Y, float(sector->floorplane.ZatPoint(sector->centerspot) + 64.0));
+
+		side.lightProbe.index = FindClosestProbe(origin);
+	}
+}
+
+static void DumpLightProbeTargets()
+{
+	for (int i = 0, size = level.sectors.size(); i < size; ++i)
+	{
+		const auto& sector = level.sectors[i];
+		Printf("Sector %d = %d\n", i, sector.lightProbe.index);
+	}
+
+	for (int i = 0, size = level.sides.size(); i < size; ++i)
+	{
+		const auto& side = level.sides[i];
+		Printf("Side %d = %d\n", i, side.lightProbe.index);
+	}
+}
+
+static void DumpLightProbes()
+{
+	for (int i = 0, size = level.lightProbes.size(); i < size; ++i)
+	{
+		const auto& probe = level.lightProbes[i];
+		Printf("Probe %d: (%.1f, %.1f, %.1f)\n", i, probe.position.X, probe.position.Y, probe.position.Z);
+	}
+}
+
+static void AddLightProbe(FVector3 position)
+{
+	LightProbe probe;
+	probe.position = position;
+	probe.index = static_cast<int>(level.lightProbes.size());
+	level.lightProbes.Push(probe);
+}
+
+CCMD(dumplightprobes)
+{
+	DumpLightProbes();
+}
+
+CCMD(dumplightprobetargets)
+{
+	DumpLightProbeTargets();
+}
+
+CCMD(addlightprobe)
+{
+	const auto pos = FVector3(players[0].mo->Pos().X, players[0].mo->Pos().Y, players[0].viewz);
+	AddLightProbe(pos);
+	RecalculateLightProbeTargets();
+
+	Printf("Spawned probe at %.1f, %.1f, %.1f\n", pos.X, pos.Y, pos.Z);
+}

--- a/src/rendering/hwrenderer/doom_lightprobes.cpp
+++ b/src/rendering/hwrenderer/doom_lightprobes.cpp
@@ -126,3 +126,20 @@ CCMD(autoaddlightprobes)
 
 	Printf("Spawned %d probes\n", probes);
 }
+
+CCMD(setlightlevel)
+{
+	if (argv.argc() < 2)
+	{
+		Printf("Usage: setlightlevel <lightlevel>\n");
+		return;
+	}
+
+	int light = std::atoi(argv[1]);
+
+	for (int i = 0, size = level.sectors.size(); i < size; ++i)
+	{
+		auto& sector = level.sectors[i];
+		sector.SetLightLevel(light);
+	}
+}

--- a/src/rendering/hwrenderer/doom_lightprobes.cpp
+++ b/src/rendering/hwrenderer/doom_lightprobes.cpp
@@ -100,3 +100,29 @@ CCMD(addlightprobe)
 
 	Printf("Spawned probe at %.1f, %.1f, %.1f\n", pos.X, pos.Y, pos.Z);
 }
+
+CCMD(autoaddlightprobes)
+{
+	int probes = 0;
+	for (int i = 0, size = level.sectors.size(); i < size; ++i)
+	{
+		auto& sector = level.sectors[i];
+		const auto origin = FVector3(sector.centerspot.X, sector.centerspot.Y, float(sector.floorplane.ZatPoint(sector.centerspot) + sector.ceilingplane.ZatPoint(sector.centerspot) / 2.f));
+
+		/*if (level.lightProbes.size() > 0)
+		{
+			auto pos = FindClosestProbe(origin);
+			if ((level.lightProbes[pos].position - origin).LengthSquared() < 256 * 256)
+			{
+				continue;
+			}
+		}*/
+
+		probes++;
+		AddLightProbe(origin);
+	}
+
+	RecalculateLightProbeTargets();
+
+	Printf("Spawned %d probes\n", probes);
+}

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -484,7 +484,6 @@ void LightProbeIncrementalBuilder::Step(const TArray<LightProbe>& probes, std::f
 	if (lastIndex >= probes.size())
 	{
 		lastIndex = 0;
-		collected = 0;
 
 		if (!probes.size())
 		{
@@ -509,6 +508,7 @@ void LightProbeIncrementalBuilder::Step(const TArray<LightProbe>& probes, std::f
 		}
 		this->irradianceMaps.Clear();
 		this->prefilterMaps.Clear();
+		collected = 0;
 	}
 }
 

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -50,8 +50,6 @@
 #include "hwrenderer/scene/hw_drawcontext.h"
 #include "hw_vrmodes.h"
 
-#include "common/rendering/vulkan/vk_lightprober.h" // to fetch irradiance and prefilter map texel counts
-
 EXTERN_CVAR(Bool, cl_capfps)
 EXTERN_CVAR(Float, r_visibility)
 EXTERN_CVAR(Bool, gl_bandedswlight)
@@ -335,7 +333,7 @@ static void CheckTimer(FRenderState &state, uint64_t ShaderStartTime)
 		state.firstFrame = screen->FrameTime - 1;
 }
 
-LightProbeIncrementalBuilder lightProbeBuilder(VkLightprober::irrandiaceMapTexelCount, VkLightprober::prefilterMapTexelCount, VkLightprober::irradianceMapChannelCount, VkLightprober::prefilterMapChannelCount);
+LightProbeIncrementalBuilder lightProbeBuilder(DFrameBuffer::irrandiaceMapTexelCount, DFrameBuffer::prefilterMapTexelCount, DFrameBuffer::irradianceMapChannelCount, DFrameBuffer::prefilterMapChannelCount);
 
 sector_t* RenderView(player_t* player)
 {

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -330,6 +330,7 @@ void HWFlat::DrawFlat(HWFlatDispatcher *di, FRenderState &state, bool translucen
 	int rel = getExtraLight();
 
 	state.SetNormal(plane.plane.Normal().X, plane.plane.Normal().Z, plane.plane.Normal().Y);
+	state.SetLightProbeIndex(sector->lightProbe.index);
 
 	SetColor(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), Colormap, alpha);
 	SetFog(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), &Colormap, false, di->di ? di->di->drawctx->portalState.inskybox : false);

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -87,6 +87,7 @@ void HWWall::RenderWall(FRenderState &state, int textured)
 	if (seg->sidedef->Flags & WALLF_DITHERTRANS) state.SetEffect(EFF_DITHERTRANS);
 	assert(vertcount > 0);
 	state.SetLightIndex(dynlightindex);
+	state.SetLightProbeIndex(seg->sidedef->lightProbe.index);
 	state.Draw(DT_TriangleFan, vertindex, vertcount);
 	vertexcount += vertcount;
 	if (seg->sidedef->Flags & WALLF_DITHERTRANS)

--- a/wadsrc/static/shaders/scene/lightmodel_pbr.glsl
+++ b/wadsrc/static/shaders/scene/lightmodel_pbr.glsl
@@ -147,7 +147,7 @@ vec3 ProcessMaterialLight(Material material, vec3 ambientLight)
 	vec3 kS = F;
 	vec3 kD = 1.0 - kS;
 
-	const float environmentScaleFactor = 0.1;
+	const float environmentScaleFactor = 1.0;
 
 	vec3 irradiance = texture(IrradianceMap, vec4(N, uLightProbeIndex)).rgb * environmentScaleFactor;
 	vec3 diffuse = irradiance * albedo;

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -97,6 +97,7 @@ version "4.12"
 #include "zscript/actors/shared/dynlights.zs"
 #include "zscript/actors/shared/corona.zs"
 #include "zscript/actors/shared/fogball.zs"
+#include "zscript/actors/shared/lightprobe.zs"
 
 #include "zscript/actors/doom/doomplayer.zs"
 #include "zscript/actors/doom/possessed.zs"

--- a/wadsrc/static/zscript/actors/shared/lightprobe.zs
+++ b/wadsrc/static/zscript/actors/shared/lightprobe.zs
@@ -4,6 +4,8 @@
 
 class LightProbe : Actor
 {
+	// note: thinker is set to STAT_INFO
+
 	Default
 	{
 		+NOINTERACTION

--- a/wadsrc/static/zscript/actors/shared/lightprobe.zs
+++ b/wadsrc/static/zscript/actors/shared/lightprobe.zs
@@ -1,0 +1,15 @@
+/*
+ Light probe actor.
+*/
+
+class LightProbe : Actor
+{
+	Default
+	{
+		+NOINTERACTION
+		+NOBLOCKMAP
+		+NOGRAVITY
+		Height 2;
+		Radius 1;
+	}
+}


### PR DESCRIPTION
Support one probe bound per side_t and sector_t (TODO: more individual pieces?)
Render cubemap per frame into buffer, before uploading as single continuous blob.
Placeholder "LightProbe" object used as viewpoint for rendering (not what it was meant for, but I needed something)

`addlightprobe` adds a probe and recalculates updates probe binding
`dumplightprobes` shows where are the probes
`dumplightprobetargets` lists which side and sector uses which probe
`autoaddlightprobes` will place lightprobes roughly at the centerpoint of all sectors (naive solution)
`gl_lightprobe 1` will keep re-rendering the probes