### PR TITLE
More Worker Threads For Specialized Shader Compilation

### DIFF
--- a/src/common/rendering/vulkan/pipelines/vk_renderpass.cpp
+++ b/src/common/rendering/vulkan/pipelines/vk_renderpass.cpp
@@ -421,7 +421,7 @@ VulkanPipeline *VkRenderPassSetup::GetPipeline(const VkPipelineKey &key, Uniform
 	else
 	{
 		auto item = SpecializedPipelines.find(key);
-		if (item == SpecializedPipelines.end())
+		if (item == SpecializedPipelines.end() || item->second.pipeline == nullptr)
 		{
 			auto pipeline = CreateWithStats(*CreatePipeline(key, false, Uniforms), "Specialized");
 			auto ptr = pipeline.get();

--- a/src/common/rendering/vulkan/pipelines/vk_renderpass.h
+++ b/src/common/rendering/vulkan/pipelines/vk_renderpass.h
@@ -171,10 +171,11 @@ public:
 	void RunOnMainThread(std::function<void()> task);
 
 private:
+	void CreatePipelineWorkThreads();
 	void CreateLightTilesPipeline();
 	void CreateZMinMaxPipeline();
 
-	void StopWorkerThread();
+	void StopWorkerThreads();
 	void WorkerThreadMain();
 
 	VulkanRenderDevice* fb = nullptr;
@@ -203,7 +204,7 @@ private:
 
 	struct
 	{
-		std::thread Thread;
+		std::vector<std::unique_ptr<std::thread>> Threads;
 		std::mutex Mutex;
 		std::condition_variable CondVar;
 		bool StopFlag = false;

--- a/src/common/rendering/vulkan/pipelines/vk_renderpass.h
+++ b/src/common/rendering/vulkan/pipelines/vk_renderpass.h
@@ -9,6 +9,8 @@
 #include "common/rendering/vulkan/shaders/vk_shader.h"
 #include <string.h>
 #include <map>
+#include <thread>
+#include <condition_variable>
 
 class VulkanRenderDevice;
 class ColorBlendAttachmentBuilder;


### PR DESCRIPTION
Fixes nullptr exception when switching to `gl_ubershaders 0`

Thread count is `std::thread::hardware_concurrency() / 2` threads (or overriden by `vk_pipeline_threads`) clamped between `1` and `std::thread::hardware_concurrency() - 2 - int(gl_multithread != 0)`

**Thread work isn't equally distributed, that may need further rework of the code.**

Fixes missing include for Linux/macOSS