### PR TITLE
changed light limit to 80k to match gzdoom

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_dynlightdata.h
+++ b/src/common/rendering/hwrenderer/data/hw_dynlightdata.h
@@ -66,7 +66,7 @@ enum FDynLightDataArrays
 	LIGHTARRAY_ADDITIVE,
 };
 
-#define MAX_LIGHT_DATA 8192
+#define MAX_LIGHT_DATA 80000
 
 struct FDynLightData
 {


### PR DESCRIPTION
~~buffer should still be only 2~3mb, not a concern vram-wise, and not even close to the 128mb minimum supported size for storage buffers~~ changed limit to 80k to match gzdoom