### PR TITLE
Squashing a visual rendering bug in stacked sector portals

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -385,14 +385,14 @@ void HWFlat::DrawFlat(HWFlatDispatcher *di, FRenderState &state, bool translucen
 			else state.AlphaFunc(Alpha_GEqual, 0.f);
 			state.SetMaterial(texture, UF_Texture, 0, CLAMP_NONE, NO_TRANSLATION, -1);
 			bool texmatrix = SetPlaneTextureRotation(state, &plane, texture);
-			if (di->di && di->di->Viewpoint.IsAllowedOoB())
+			if (di->di) // dpjudas, gl_levelmesh could use zshift for reflective flats. - [DVR]
 			{
 				di->di->VPUniforms.mViewMatrix.translate(0.0, zshift, 0.0);
 				di->di->vpIndex = state.SetViewpoint(di->di->VPUniforms);
 				// screen->mViewpoints->SetViewpoint(state, &di->di->VPUniforms);
 			}
 			DrawSubsectors(di, state);
-			if (di->di && di->di->Viewpoint.IsAllowedOoB())
+			if (di->di)
 			{
 				di->di->VPUniforms.mViewMatrix.translate(0.0, -zshift, 0.0);
 				di->di->vpIndex = state.SetViewpoint(di->di->VPUniforms);

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -835,7 +835,7 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 void HWSectorStackPortal::DrawPortalStencil(FRenderState &state, int pass)
 {
-	if (mState->vpIsAllowedOoB)
+	if (true) // mState->vpIsAllowedOoB)
 	{
 		bool isceiling = planesused & (1 << sector_t::ceiling);
 		for (unsigned i = 0; i<subsectors.Size(); i++)
@@ -916,7 +916,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 {
-	if (mState->vpIsAllowedOoB)
+	if (true) // mState->vpIsAllowedOoB)
 	{
 		bool isceiling = planesused & (1 << sector_t::ceiling);
 		for (unsigned int i = 0; i < lines.Size(); i++)

--- a/src/rendering/hwrenderer/scene/hw_sky.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sky.cpp
@@ -315,15 +315,16 @@ void HWWall::SkyTop(HWWallDispatcher *di, FRenderState& state, seg_t * seg,secto
 		float frontreflect = fs->GetReflect(sector_t::ceiling);
 		if (frontreflect > 0)
 		{
-			float backreflect = bs->GetReflect(sector_t::ceiling);
-			if (backreflect > 0 && bs->ceilingplane.fD() == fs->ceilingplane.fD() && !bs->isClosed())
-			{
-				// Don't add intra-portal line to the portal.
-				if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
-				{
-					return;
-				}
-			}
+			// [DVR] Changed the stencil for planemirrors, so now I need intra-portal lines
+			// float backreflect = bs->GetReflect(sector_t::ceiling);
+			// if (backreflect > 0 && bs->ceilingplane.fD() == fs->ceilingplane.fD() && !bs->isClosed())
+			// {
+			// 	// Don't add intra-portal line to the portal.
+			// 	if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
+			// 	{
+			// 		return;
+			// 	}
+			// }
 		}
 		else
 		{
@@ -397,15 +398,16 @@ void HWWall::SkyBottom(HWWallDispatcher *di, FRenderState& state, seg_t * seg,se
 		float frontreflect = fs->GetReflect(sector_t::floor);
 		if (frontreflect > 0)
 		{
-			float backreflect = bs->GetReflect(sector_t::floor);
-			if (backreflect > 0 && bs->floorplane.fD() == fs->floorplane.fD() && !bs->isClosed())
-			{
-				// Don't add intra-portal line to the portal.
-				if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
-				{
-					return;
-				}
-			}
+			// [DVR] Changed the stencil for planemirrors, so now I need intra-portal lines
+			// float backreflect = bs->GetReflect(sector_t::floor);
+			// if (backreflect > 0 && bs->floorplane.fD() == fs->floorplane.fD() && !bs->isClosed())
+			// {
+			// 	// Don't add intra-portal line to the portal.
+			// 	if (!(di->di && di->di->Viewpoint.IsAllowedOoB()))
+			// 	{
+			// 		return;
+			// 	}
+			// }
 		}
 		else
 		{


### PR DESCRIPTION
Non-levelmesh artifacts in stacked-sector portals and planemirrors.

See: https://github.com/ZDoom/gzdoom/pull/3183

vkdoom-centric version. 
Load maps and look down.

[visual_bug_floormaps.zip](https://github.com/user-attachments/files/21093204/visual_bug_floormaps.zip)
